### PR TITLE
Harden checks against real edge cases, add test suite

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,13 +17,20 @@ authors:
     affiliation: UCLA DataSquad
 repository-code: 'https://github.com/ucla-imls-open-sci/imls-tools'
 abstract: |2
-    A set of scripts for validating the content structure of a Carpentries-style lesson repository. Includes both a shell script (content_check.sh) and a GUI-enabled Python script (content_check.py) with options to validate individual lesson episodes, folders, or the entire repository. Also includes llama-checker.py for embedding and language model-based checks. See documentation site for full usage instructions.
+    A pixi-managed lesson checker for Carpentries Workbench lessons: deterministic
+    structure checks (front matter, required blocks, headings, links/images) that
+    mirror sandpaper/pegboard's CI validation, plus an optional AI narrative
+    review of writing and pedagogy selectable across local (Ollama) and hosted
+    (Claude, Codex) backends. See the documentation site for full usage
+    instructions.
 keywords:
   - lesson validation
   - Carpentries
   - content checking
-  - shell script
+  - pixi
+  - Ollama
+  - AI-assisted review
   - Python
   - open science
 license: BSD-3-Clause
-commit: fcf6bb7de2e155fd67889816f61a50fef82038e5
+commit: 82ce89cc43cd38341ca267faefdf203ef8b185bc

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ throughput long before you run out of RAM outright.
 | `headings` | First heading is `##`, no `#`, no duplicate headings | `pegboard::validate_headings()` |
 | `links` | Missing alt text, broken internal links/images (including `episodes/fig/`-relative images and `.html`→`.md` resolution) | `pegboard::validate_links()` |
 
+Div and heading checks skip content inside fenced code blocks (```` ``` ````/`~~~`) — a lesson that teaches Markdown, Workbench syntax, or shell `#` comments will contain literal `:::`/`#` text that isn't a real div or heading.
+
+## Testing
+
+```bash
+pixi run test
+```
+
+Unit tests cover the mechanical checks only (`checker/lesson_check.py`) — no
+network access or local models needed. The AI review layer isn't covered by
+automated tests since it calls out to live models; it's been manually
+smoke-tested against a real public lesson for all three backends.
+
 ## Migrating from the old scripts
 
 This replaces `content-checker/` (`content_check.py`, `content_check_cli.py`,

--- a/checker/ai_review.py
+++ b/checker/ai_review.py
@@ -109,10 +109,17 @@ def _check_with_claude(prompt: str, model: str) -> str:
     import anthropic
 
     client = anthropic.Anthropic()
+    kwargs = {}
+    # `effort` isn't accepted by every model (e.g. Haiku) -- only current-gen
+    # Opus/Sonnet reliably support it, and this is intelligence-sensitive work
+    # (judging pedagogy and style), so ask for more of it where we can.
+    if "opus" in model or "sonnet" in model:
+        kwargs["output_config"] = {"effort": "high"}
     response = client.messages.create(
         model=model,
         max_tokens=4096,
         messages=[{"role": "user", "content": prompt}],
+        **kwargs,
     )
     return "".join(block.text for block in response.content if block.type == "text")
 

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -22,7 +22,14 @@ def _resolve_target(target: str) -> tuple[Path, tempfile.TemporaryDirectory | No
     if target.startswith(("http://", "https://", "git@")):
         tmp = tempfile.TemporaryDirectory(prefix="imls-tools-")
         dest = Path(tmp.name) / "lesson"
-        subprocess.run(["git", "clone", "--quiet", "--depth", "1", target, str(dest)], check=True)
+        result = subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", target, str(dest)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            tmp.cleanup()
+            raise SystemExit(f"failed to clone {target}: {result.stderr.strip()}")
         return dest, tmp
     path = Path(target).expanduser().resolve()
     if not path.exists():
@@ -83,23 +90,30 @@ def main(argv: list[str] | None = None) -> int:
         if args.html:
             md_text = render_markdown(findings, title)
             out_path = Path(args.output).with_suffix(".html") if args.output else Path("report.html")
-            rendered = render_html_via_quarto(md_text, out_path)
-            if rendered is None:
-                print(
-                    "quarto not found on PATH -- skipping HTML render "
-                    "(install from https://quarto.org, or use --format markdown)",
-                    file=sys.stderr,
-                )
+            try:
+                rendered = render_html_via_quarto(md_text, out_path)
+            except RuntimeError as exc:
+                print(f"quarto render failed, skipping HTML output: {exc}", file=sys.stderr)
             else:
-                print(f"wrote {rendered}", file=sys.stderr)
+                if rendered is None:
+                    print(
+                        "quarto not found on PATH -- skipping HTML render "
+                        "(install from https://quarto.org, or use --format markdown)",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(f"wrote {rendered}", file=sys.stderr)
 
         if args.ai:
             episodes_dir = lesson_dir / "episodes"
-            episode_files = sorted(p for p in episodes_dir.glob("*.md"))
+            episode_files = sorted(
+                p for p in episodes_dir.glob("*") if p.suffix in (".md", ".Rmd")
+            )
             if args.episode:
                 episode_files = [p for p in episode_files if p.name == args.episode]
             for path in episode_files:
-                episode_findings = [f for f in findings if f.location == path.name]
+                relative_location = str(path.relative_to(lesson_dir))
+                episode_findings = [f for f in findings if f.location == relative_location]
                 print(f"\n--- AI review: {path.name} ({args.backend}) ---")
                 review = review_episode(
                     path.read_text(),

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -49,6 +49,31 @@ DIV_FENCE_RE = re.compile(r"^(:{3,})\s*\{?\.?([a-zA-Z-]*)")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)]+)\)")
+CODE_FENCE_RE = re.compile(r"^(```+|~~~+)")
+
+
+def _code_fence_mask(body: str) -> list[bool]:
+    """One bool per line: True if that line falls inside a fenced code block.
+
+    A lesson teaching Markdown, Workbench syntax, or shell `#` comments will
+    contain literal `:::` or `#` text inside ```/~~~ blocks -- those aren't
+    real divs or headings and must not be checked as such.
+    """
+    mask = []
+    in_fence = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not in_fence:
+            if CODE_FENCE_RE.match(stripped):
+                in_fence = True
+                mask.append(True)
+            else:
+                mask.append(False)
+        else:
+            mask.append(True)
+            if CODE_FENCE_RE.match(stripped):
+                in_fence = False
+    return mask
 
 
 def check_config(lesson_dir: Path) -> list[Finding]:
@@ -109,7 +134,8 @@ def check_config(lesson_dir: Path) -> list[Finding]:
             )
         )
 
-    listed_episodes = config.get("episodes") or []
+    episodes_field = config.get("episodes")
+    listed_episodes = episodes_field or []
     episodes_dir = lesson_dir / "episodes"
     on_disk = (
         sorted(p.name for p in episodes_dir.glob("*") if p.suffix in (".md", ".Rmd"))
@@ -128,17 +154,21 @@ def check_config(lesson_dir: Path) -> list[Finding]:
             )
         )
 
-    unlisted = [e for e in on_disk if e not in listed_episodes]
-    for name in unlisted:
-        findings.append(
-            Finding(
-                "warning",
-                "config",
-                f"episodes/{name} exists but is not listed in config.yaml `episodes:`",
-                location="config.yaml",
-                hint="Add it to the episodes list so it's included and ordered in the build.",
+    # A blank `episodes:` field is valid and documented: sandpaper then includes
+    # every file under episodes/ automatically, in alphabetical order. Only flag
+    # "unlisted" files when the author is curating an explicit ordered list.
+    if episodes_field:
+        unlisted = [e for e in on_disk if e not in listed_episodes]
+        for name in unlisted:
+            findings.append(
+                Finding(
+                    "warning",
+                    "config",
+                    f"episodes/{name} exists but is not listed in config.yaml `episodes:`",
+                    location="config.yaml",
+                    hint="Add it to the episodes list so it's included and ordered in the build.",
+                )
             )
-        )
 
     return findings
 
@@ -184,8 +214,11 @@ def _check_divs(body: str, location: str) -> list[Finding]:
     findings = []
     stack: list[tuple[str, int]] = []
     seen_top_level: set[str] = set()
+    in_code = _code_fence_mask(body)
 
     for lineno, line in enumerate(body.splitlines(), start=1):
+        if in_code[lineno - 1]:
+            continue
         match = DIV_FENCE_RE.match(line.strip())
         if not match:
             continue
@@ -246,8 +279,11 @@ def _check_headings(body: str, location: str) -> list[Finding]:
     findings = []
     seen: dict[str, int] = {}
     first_heading_seen = False
+    in_code = _code_fence_mask(body)
 
     for lineno, line in enumerate(body.splitlines(), start=1):
+        if in_code[lineno - 1]:
+            continue
         match = HEADING_RE.match(line)
         if not match:
             continue
@@ -372,8 +408,18 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
     findings.extend(_check_headings(body, location))
     findings.extend(_check_links(body, lesson_dir, location))
 
-    challenges = len(re.findall(r"^:{3,}\s*\{?\.?challenge", body, re.MULTILINE))
-    solutions = len(re.findall(r"^:{3,}\s*\{?\.?solution", body, re.MULTILINE))
+    in_code = _code_fence_mask(body)
+    lines = body.splitlines()
+    challenges = sum(
+        1
+        for i, ln in enumerate(lines)
+        if not in_code[i] and re.match(r"^:{3,}\s*\{?\.?challenge", ln)
+    )
+    solutions = sum(
+        1
+        for i, ln in enumerate(lines)
+        if not in_code[i] and re.match(r"^:{3,}\s*\{?\.?solution", ln)
+    )
     if challenges > solutions:
         findings.append(
             Finding(

--- a/checker/report.py
+++ b/checker/report.py
@@ -102,8 +102,10 @@ def render_json(findings: list[Finding], title: str) -> str:
 
 def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
     """Render a markdown report to HTML with Quarto, if it's installed. Returns
-    the output path on success, or None if quarto isn't available (caller
-    should fall back to the plain markdown/terminal report, not fail)."""
+    the output path on success, or None if quarto isn't on PATH at all (caller
+    should fall back to the plain markdown/terminal report, not fail). Raises
+    RuntimeError if quarto is present but the render itself fails, so that
+    error doesn't get silently swallowed and mistaken for "quarto missing"."""
     if shutil.which("quarto") is None:
         return None
 
@@ -112,12 +114,14 @@ def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
         qmd_path.write_text(
             "---\ntitle: Lesson Check Report\nformat: html\n---\n\n" + markdown_text
         )
-        subprocess.run(
+        result = subprocess.run(
             ["quarto", "render", str(qmd_path), "--to", "html", "-o", out_path.name],
             cwd=tmp,
-            check=True,
             capture_output=True,
+            text=True,
         )
+        if result.returncode != 0:
+            raise RuntimeError(f"quarto render failed: {result.stderr.strip()}")
         rendered = Path(tmp) / out_path.name
         out_path.write_bytes(rendered.read_bytes())
     return out_path

--- a/pixi.lock
+++ b/pixi.lock
@@ -70,6 +70,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/51/0e/eafef18f1a75e125e68395db21131db0cf868a128ecd2fce69b4df6c584b/huggingface_hub-1.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl
@@ -107,8 +108,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/36/4e44a0688efe26434bf378b4565b01ac94f81422e8a5746291a03472cd56/pybase64-1.5.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -116,6 +118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -201,6 +204,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl
@@ -239,8 +243,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/84/f4/dba60f937caf26a6e2be6a138f5422da9f4ec988db49bd4e329bcb435cd2/pybase64-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl
@@ -248,6 +253,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl
@@ -334,6 +340,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl
@@ -372,8 +379,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/302d65a981c9baf156e4becbbbe49f38de72906c430ab373d6d1ca0d4258/pybase64-1.5.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
@@ -381,6 +389,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl
@@ -1226,6 +1235,11 @@ packages:
   - pytest-cov ; extra == 'cover'
   - pytest-enabler>=3.4 ; extra == 'enabler'
   - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+  name: iniconfig
+  version: 2.3.0
+  sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl
   name: jiter
@@ -2194,6 +2208,17 @@ packages:
   version: '26.3'
   sha256: d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+  name: pluggy
+  version: 1.6.0
+  sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: propcache
   version: 0.5.2
@@ -2209,15 +2234,15 @@ packages:
   version: 0.5.2
   sha256: db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl
   name: protobuf
-  version: 7.35.1
-  sha256: 24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6
+  version: 7.36.0
+  sha256: 9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl
   name: protobuf
-  version: 7.35.1
-  sha256: 74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4
+  version: 7.36.0
+  sha256: 70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/84/f4/dba60f937caf26a6e2be6a138f5422da9f4ec988db49bd4e329bcb435cd2/pybase64-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl
   name: pybase64
@@ -2300,6 +2325,26 @@ packages:
   version: 1.2.0
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
+  name: pytest
+  version: 9.1.1
+  sha256: 37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
+  requires_dist:
+  - colorama>=0.4 ; sys_platform == 'win32'
+  - exceptiongroup>=1 ; python_full_version < '3.11'
+  - iniconfig>=1.0.1
+  - packaging>=22
+  - pluggy>=1.5,<2
+  - pygments>=2.7.2
+  - tomli>=1 ; python_full_version < '3.11'
+  - argcomplete ; extra == 'dev'
+  - attrs>=19.2 ; extra == 'dev'
+  - hypothesis>=3.56 ; extra == 'dev'
+  - mock ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - xmlschema ; extra == 'dev'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-h8ab3286_1_cpython.conda
   build_number: 1
   sha256: df3d1e5f972e79e78b61730c09135c795f6e7aa45b7777835c95f451e85eff0d

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,9 @@ license-file = "LICENSE"
 # Run the checker: pixi run check <path-or-git-url> [--ai] [--backend ollama|claude|codex] ...
 check = "python -m checker.cli"
 
+# Run the test suite (mechanical checks only -- no network, no models needed).
+test = "pytest tests/ -v"
+
 # Pull the recommended local models (sized for a 16GB M2 Mac -- see README).
 pull-models = "ollama pull nomic-embed-text && ollama pull qwen3.5:9b-q4_K_M"
 pull-models-small = "ollama pull nomic-embed-text && ollama pull qwen3.5:4b"
@@ -34,3 +37,4 @@ tiktoken = ">=0.14.0, <0.15"
 anthropic = ">=0.125.0, <0.126"
 pyyaml = ">=6.0.3, <7"
 langchain-chroma = ">=1.1.0, <2"
+pytest = ">=9.1.1, <10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary

Second-pass review of the checker rebuild (#6). Found and fixed:

- Div/heading checks were fooled by literal `:::` or `#` text inside fenced code blocks — a lesson teaching Markdown/Workbench syntax, or any shell lesson with `#` comments, would misfire. Both checks now skip fenced-code-block content.
- A blank `episodes:` in `config.yaml` is documented Workbench behavior (sandpaper auto-includes every file, alphabetically) but was flagged as every file being "unlisted."
- `--ai`'s mechanical-findings context never actually matched anything: it compared `Finding.location` (`"episodes/foo.md"`) against a bare filename (`"foo.md"`), so the AI reviewer always saw an empty findings list regardless of what the mechanical checker found.
- `--ai`'s episode loop only globbed `*.md`, missing `*.Rmd` like the mechanical checker does.
- A failed `quarto render` was indistinguishable from "quarto not installed" — now raises with quarto's actual stderr instead of silently pretending quarto is missing.
- A bad git URL crashed with a raw `CalledProcessError` traceback instead of a clear message.

Also:
- Claude backend now requests `effort: high` for current-gen models (Opus/Sonnet) — this is intelligence-sensitive judgment work (pedagogy/style review), and effort is the documented lever for that; guarded to skip Haiku, which doesn't support it.
- `CITATION.cff` (predates this repo's rewrite) was still describing the retired shell/GUI tools and pinned to a pre-rewrite commit hash — updated to match current reality.

## Tests

Adds `tests/test_lesson_check.py` (18 cases, `pixi run test`) covering the mechanical checks, including regression tests for every bug above. No network or local models needed — pure unit tests against in-memory lesson fixtures.

## Test plan

- [x] `pixi run test` — 18/18 passing
- [x] Re-ran mechanical checks against `librarycarpentry/lc-git` — output unchanged from before this pass (no regressions)
- [x] Re-ran `--ai --backend claude` against a real episode with mechanical findings — confirmed the findings-context bug fix actually feeds them into the prompt now