### PR TITLE
Fix bugs found by external validation, add CI (missed by #8's early merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.61.0
+          cache: true
+      - run: pixi run test

--- a/checker/ai_review.py
+++ b/checker/ai_review.py
@@ -39,11 +39,48 @@ REFERENCE_URLS = [
     "https://carpentries.github.io/sandpaper-docs/episodes.html",
     # Collaborative Lesson Development Training: backward design, SMART
     # objectives, formative assessment cadence, scope management, accessibility.
+    # Retrieval is fine for this one -- it's long, and we only want the parts
+    # relevant to a given episode (elaboration/examples), not the whole thing
+    # verbatim in every prompt.
     "https://carpentries.github.io/lesson-development-training/aio.html",
-    # The Carpentries Lab's actual lesson-reviewer checklist -- this is the
-    # rubric a human reviewer would grade the lesson against.
-    "https://raw.githubusercontent.com/carpentries-lab/reviews/main/docs/reviewer_guide.md",
 ]
+
+# The Carpentries Lab's actual lesson-reviewer checklist -- the rubric a human
+# reviewer grades against. This is pinned directly into every prompt rather
+# than left to retrieval: it's short, and a rubric that might or might not
+# surface depending on chunk similarity isn't a rubric the review can be held
+# to. Retrieval above is for elaboration/examples; this is the actual grading
+# criteria. Verbatim from https://github.com/carpentries-lab/reviews/blob/main/docs/reviewer_guide.md
+LAB_CHECKLIST = """\
+Accessibility:
+- The alternative text of all figures is accurate and sufficiently detailed
+- The lesson content does not make extensive use of colloquialisms, region- or \
+culture-specific references, or idioms
+- The lesson content does not make extensive use of contractions
+
+Content:
+- Meets the objectives defined by the authors
+- Is appropriate for the target audience identified for the lesson
+- Is accurate, descriptive, and easy to understand
+- Is appropriately structured to manage cognitive load
+- Does not use dismissive language
+- The solutions to all exercises are accurate and sufficiently explained
+- The lesson includes exercises in a variety of formats
+- Exercise tasks and formats are appropriate for the expected experience level
+- All lesson and episode objectives are assessed by exercises or another \
+opportunity for formative assessment
+- Exercises are designed with diagnostic power
+
+Design:
+- Learning objectives for the lesson and its episodes are clear, descriptive, \
+and measurable
+- The target audience identified for the lesson is specific and realistic
+
+Supporting Information:
+- The list of required prior skills and/or knowledge is complete and accurate
+- The setup and installation instructions are complete, accurate, and easy to follow
+- No key terms are missing from the lesson glossary
+"""
 
 EMBED_MODEL = "nomic-embed-text"
 
@@ -86,26 +123,40 @@ def _build_prompt(episode_text: str, findings: list[Finding], style_context: str
         or "(none -- the episode passed all mechanical structure checks)"
     )
     return f"""You are reviewing a Carpentries Workbench lesson episode the way a human
-reviewer for The Carpentries Lab would, using the official style guide, the
-Collaborative Lesson Development Training guidance, and the Lab's own
-reviewer checklist as your reference.
+reviewer for The Carpentries Lab would.
 
-Reference excerpts (retrieved for relevance to this episode):
+The Carpentries Lab reviewer checklist -- grade against this directly, it is
+the actual rubric, not just background reading:
+{LAB_CHECKLIST}
+
+Supporting guidance (style guide + Collaborative Lesson Development Training,
+retrieved for relevance to this episode -- use for elaboration and examples,
+the checklist above is the grading criteria):
 {style_context}
 
 Mechanical structure issues already found by an automated checker (do not
 repeat these -- focus on what a checker can't catch):
 {mechanical_summary}
 
+One of the mechanical checks flags objectives that *open* with a vague verb
+(know/understand/appreciate/...) as a cheap heuristic. Do not treat that as
+your own standard: a verb not matching that denylist does not make an
+objective assessable, and a verb matching it does not make it unassessable
+("recognize" and "distinguish" can both be perfectly observable with the
+right exercise, "explain" can still be vague without one). Judge each
+objective by whether attainment is actually observable given what the
+episode assesses -- and if nothing does, say so, since that is the more
+useful finding than quibbling over the opening word.
+
 Episode text:
 ---
 {episode_text}
 ---
 
-Give a short narrative review (bulleted is fine), grading against the same
-criteria a Carpentries Lab reviewer uses:
-1. Learning objectives: are they specific and measurable (SMART), not just
-   grammatically an action verb but genuinely observable/assessable?
+Give a short narrative review (bulleted is fine), grading against the
+checklist above:
+1. Learning objectives: are they specific and measurable, genuinely
+   observable/assessable given what the episode actually tests?
 2. Formative assessment: do challenges/exercises actually test each
    objective, with enough variety and diagnostic power to catch
    misconceptions -- not just "type this command and see what happens"?

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -46,24 +46,37 @@ CONFIG_PLACEHOLDER_VALUES = {
 
 # Collaborative Lesson Development Training (carpentries.github.io/lesson-development-training)
 # and The Carpentries Lab reviewer checklist (github.com/carpentries-lab/reviews) both call out
-# weak, unmeasurable objective verbs -- prefer "explain"/"choose"/"predict" over these.
-PASSIVE_OBJECTIVE_VERBS = (
-    "know",
-    "understand",
-    "appreciate",
-    "learn about",
-    "be familiar with",
-    "be aware of",
-    "grasp",
+# weak, unmeasurable objective verbs -- prefer "explain"/"choose"/"predict" over these. This is
+# a denylist of *openers*, not a verb classifier: a verb absent from this list is not thereby
+# "good", and a match here means "worth a second look", not "wrong" -- CLDT's actual test is
+# whether attainment is directly observable, not which word an objective happens to start with.
+VAGUE_OBJECTIVE_OPENER_RE = re.compile(
+    r"^(know|understand|appreciate|learn about|be familiar with|become familiar with|"
+    r"be aware of|grasp|(?:gain|develop) an understanding of)\b",
+    re.IGNORECASE,
 )
 
-# Lab checklist: "does not make extensive use of contractions" (accessibility --
-# translation and ESL learners in particular).
-CONTRACTION_RE = re.compile(r"\b\w+'(t|s|re|ve|ll|d|m)\b", re.IGNORECASE)
+# Contractions are a closed set (pronoun/auxiliary + 't/'s/'re/...), unlike possessives
+# (any noun + 's) -- matching \w+ before the apostrophe wrongly counts "learner's"/"Git's"
+# as contractions. ’ covers curly/smart apostrophes from copy-pasted prose.
+_CONTRACTION_STEMS = (
+    "don", "doesn", "didn", "won", "wouldn", "can", "couldn", "shouldn", "isn", "aren",
+    "wasn", "weren", "hasn", "haven", "hadn", "mustn", "needn", "shan",
+    "i", "you", "he", "she", "it", "we", "they", "who", "what", "that", "there", "here",
+    "let", "how", "where", "when", "why",
+)
+CONTRACTION_RE = re.compile(
+    r"\b(?:" + "|".join(_CONTRACTION_STEMS) + r")['’](?:t|s|re|ve|ll|d|m)\b",
+    re.IGNORECASE,
+)
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
 
 # Lab checklist + CLDT: "descriptive link text" -- avoid generic phrases that
 # say nothing out of context (screen readers, translation).
-GENERIC_LINK_TEXT = {"here", "click here", "this link", "link", "click", "this"}
+GENERIC_LINK_TEXT = {
+    "here", "click here", "this link", "link", "click", "this",
+    "this page", "read more", "learn more",
+}
 
 FRONT_MATTER_RE = re.compile(r"^---\n(.*?\n)---\n(.*)$", re.DOTALL)
 DIV_FENCE_RE = re.compile(r"^(:{3,})\s*\{?\.?([a-zA-Z-]*)")
@@ -191,15 +204,23 @@ def check_config(lesson_dir: Path) -> list[Finding]:
                 )
             )
 
-    if not (lesson_dir / "reference.md").exists():
+    # Workbench's actual convention is learners/reference.md (confirmed against
+    # both carpentries/workbench-template-md and a real published lesson) --
+    # accept a legacy root-level reference.md too, since older lessons may
+    # still have it there.
+    glossary_candidates = (
+        lesson_dir / "learners" / "reference.md",
+        lesson_dir / "reference.md",
+    )
+    if not any(p.exists() for p in glossary_candidates):
         findings.append(
             Finding(
                 "info",
                 "config",
-                "no reference.md (glossary) found at the lesson root",
+                "no glossary file found (learners/reference.md)",
                 location="config.yaml",
-                hint="The Carpentries Lab reviewer checklist checks that no key terms are "
-                "missing from the lesson glossary.",
+                hint="[Carpentries Lab] Checks that no key terms are missing from the "
+                "lesson glossary. This only checks the file exists, not its contents.",
             )
         )
 
@@ -252,23 +273,26 @@ def _check_front_matter(front_matter: dict, location: str) -> list[Finding]:
                     f"episode is {total:g} min (teaching + exercises), outside the "
                     "20-60 min range Collaborative Lesson Development Training suggests",
                     location=location,
-                    hint="Not a hard rule -- but very short or very long episodes are "
+                    hint="[CLDT] Not a hard rule -- but very short or very long episodes are "
                     "worth a second look for scope.",
                 )
             )
     return findings
 
 
-def _check_objective_verbs(body: str, location: str) -> list[Finding]:
-    """Flag objectives that open with a hard-to-assess verb (know/understand/...)
-    instead of an action verb (explain/choose/predict/...) -- see CLDT's SMART
-    objectives guidance and the Carpentries Lab reviewer checklist."""
+def _check_objective_verbs(body: str, location: str) -> tuple[list[Finding], int]:
+    """Flag objectives that open with a verb that's often hard to assess
+    (know/understand/...) instead of an action verb (explain/choose/predict/...)
+    -- see CLDT's SMART objectives guidance and the Carpentries Lab reviewer
+    checklist. Also returns the objective bullet count, reused by check_episode()
+    for the "2-4 objectives per episode" and "assessed by an exercise" checks."""
     findings = []
     in_code = _code_fence_mask(body)
     lines = body.splitlines()
     depth = 0
     in_objectives = False
     objectives_depth = None
+    objective_count = 0
 
     for i, line in enumerate(lines):
         if in_code[i]:
@@ -293,44 +317,67 @@ def _check_objective_verbs(body: str, location: str) -> list[Finding]:
         if not stripped.startswith(("-", "*")):
             continue
         bullet_text = stripped.lstrip("-* ").strip()
-        lower = bullet_text.lower()
-        for verb in PASSIVE_OBJECTIVE_VERBS:
-            if lower.startswith(verb):
-                findings.append(
-                    Finding(
-                        "warning",
-                        "objectives",
-                        f'objective starts with a hard-to-assess verb ("{verb}"): '
-                        f'"{bullet_text[:70]}"',
-                        location=location,
-                        hint="Prefer an action verb (explain, choose, predict, ...) -- "
-                        "it's hard to observe whether a learner has developed the skill "
-                        "otherwise.",
-                    )
+        objective_count += 1
+        verb_match = VAGUE_OBJECTIVE_OPENER_RE.match(bullet_text)
+        if verb_match:
+            findings.append(
+                Finding(
+                    "warning",
+                    "objectives",
+                    f'objective opens with a phrase that can be hard to assess '
+                    f'("{verb_match.group(1)}"): "{bullet_text[:70]}"',
+                    location=location,
+                    hint="[CLDT] Not a hard rule -- judge by whether attainment is directly "
+                    "observable, not just the opening word. An action verb (explain, "
+                    "choose, predict, ...) usually makes that easier to write.",
                 )
-                break
+            )
 
-    return findings
+    if objective_count > 4:
+        findings.append(
+            Finding(
+                "info",
+                "objectives",
+                f"{objective_count} objectives in this episode",
+                location=location,
+                hint="[CLDT] Aim for 2-4 objectives per episode; consider splitting into "
+                "multiple episodes if you need more.",
+            )
+        )
+
+    return findings, objective_count
 
 
 def _check_contractions(body: str, location: str) -> list[Finding]:
     """The Carpentries Lab reviewer checklist flags heavy contraction use as an
-    accessibility concern for translation and ESL learners."""
+    accessibility concern for translation and ESL learners. Contractions are a
+    closed set of stems (it's, don't, ...), unlike possessives (any noun + 's),
+    so CONTRACTION_RE only matches known stems -- and inline code spans are
+    stripped first so identifiers like `don't_do_this` don't get counted."""
     in_code = _code_fence_mask(body)
-    count = sum(
-        len(CONTRACTION_RE.findall(line))
-        for i, line in enumerate(body.splitlines())
-        if not in_code[i]
-    )
-    if count >= 5:
+    contraction_count = 0
+    word_count = 0
+    for i, line in enumerate(body.splitlines()):
+        if in_code[i]:
+            continue
+        prose = INLINE_CODE_RE.sub(" ", line)
+        contraction_count += len(CONTRACTION_RE.findall(prose))
+        word_count += len(prose.split())
+
+    if word_count == 0:
+        return []
+    rate_per_1000 = contraction_count / word_count * 1000
+    if contraction_count >= 5 and rate_per_1000 >= 5:
         return [
             Finding(
                 "info",
                 "style",
-                f"{count} contractions found in this episode",
+                f"{contraction_count} contractions found ({rate_per_1000:.1f} per 1,000 "
+                "words)",
                 location=location,
-                hint="Consider spelling them out (don't -> do not) for translation and "
-                "ESL learners.",
+                hint="[Carpentries Lab] Consider spelling them out (don't -> do not) for "
+                "translation and ESL learners. This threshold is a local heuristic, not "
+                "an official Carpentries rule.",
             )
         ]
     return []
@@ -493,8 +540,9 @@ def _check_links(body: str, lesson_dir: Path, location: str) -> list[Finding]:
                         "links",
                         f'generic link text "{text}" on line {lineno}',
                         location=location,
-                        hint="Screen readers and translation tools lose context with "
-                        "generic link text like 'click here' -- describe the destination.",
+                        hint="[CLDT/Carpentries Lab] Screen readers and translation tools "
+                        "lose context with generic link text like 'click here' -- "
+                        "describe the destination.",
                     )
                 )
             if path.startswith(("http://", "https://", "#", "mailto:", "{{")):
@@ -544,8 +592,24 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
     findings.extend(_check_divs(body, location))
     findings.extend(_check_headings(body, location))
     findings.extend(_check_links(body, lesson_dir, location))
-    findings.extend(_check_objective_verbs(body, location))
+    objective_findings, objective_count = _check_objective_verbs(body, location)
+    findings.extend(objective_findings)
     findings.extend(_check_contractions(body, location))
+
+    # [Carpentries Lab]: "All lesson and episode objectives are assessed by
+    # exercises or another opportunity for formative assessment."
+    if objective_count > 0 and front_matter.get("exercises") == 0:
+        findings.append(
+            Finding(
+                "warning",
+                "objectives",
+                f"{objective_count} objective(s) declared but exercises: 0 -- nothing "
+                "in this episode formally assesses them",
+                location=location,
+                hint="[Carpentries Lab] Consider adding a challenge, discussion, or "
+                "other formative-assessment checkpoint.",
+            )
+        )
 
     in_code = _code_fence_mask(body)
     lines = body.splitlines()

--- a/design/validation-prompt-pedagogy-checks-2026-08-20.md
+++ b/design/validation-prompt-pedagogy-checks-2026-08-20.md
@@ -229,3 +229,46 @@ you're unsure rather than hedging generically. End with:
 - The single highest-priority fix before anything else, and why it beats
   the other candidates — including whether that's "add CI" over any of the
   check-quality issues above.
+
+## Adjudication outcome (2026-08-20)
+
+External model gave a confidence of 7/10 as-shipped, 8/10 once two specific
+bugs were fixed, with "add CI, make it required" as the top-priority fix.
+
+Verified independently before adopting anything (two turned out to be real
+confirmed bugs, one specific number turned out to be accurate, one was
+rejected on the reviewer's own reasoning):
+
+- **Glossary path** — confirmed real bug via `gh api` against
+  `workbench-template-md` and `librarycarpentry/lc-git`: both use
+  `learners/reference.md`, not the root-level path the check used. Fixed.
+- **Objective-verb word boundary** — confirmed real bug by reproducing it
+  directly: `.startswith("know")` matched "Knowledgeable use of Git". Fixed
+  with a proper regex.
+- **Contraction regex** — confirmed real bug by reproducing it: `\w+'s`
+  matched "learner's"/"Git's" as contractions. Rewrote against a closed set
+  of contractable stems, added rate normalization.
+- **"2-4 objectives per episode"** — verified as real, verbatim CLDT
+  guidance (re-fetched the page) rather than assumed accurate. Implemented
+  as an episode-scoped check.
+- **Lesson-level 3-4-objectives/6hr ratio** — rejected, agreeing with the
+  reviewer's own stated reasoning (no reliable way to locate lesson-level
+  objectives yet); implemented the episode-level version instead.
+- **Pin the Lab checklist verbatim into the prompt** rather than leave it to
+  retrieval — adopted, cheap and directly addresses "retrieval can omit the
+  very rubric it's supposed to enforce."
+- **Add CI** (`pixi run test` on push/PR) — adopted immediately, given it's
+  the direct fix for how the previous round's test suite went uncommitted
+  for a full review cycle undetected.
+- **Make CI a required status check** (branch protection) — deferred, asked
+  the maintainer directly rather than assumed, since it's a repo-wide policy
+  change affecting other collaborators, not a code fix.
+- Dataset CC0/license evidence reporting, per-topic retrieval rework, and
+  lesson-level teaching-time summaries were all deferred as new scope, not
+  bugs — no evidence yet they're worth the added complexity.
+
+Result: `checker/lesson_check.py`, `checker/ai_review.py`, and
+`tests/test_lesson_check.py` updated; `.github/workflows/test.yml` added;
+recalibrated against `~/projects/lessons/content` (real local lessons) to
+confirm the fixes fire on genuine signal, not just the synthetic test cases.
+35/35 tests passing. See PR #8 on `ucla-imls-open-sci/imls-tools`.

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -241,14 +241,29 @@ def test_links_generic_link_text_is_warning(tmp_path):
 # -- objectives (CLDT / Carpentries Lab checklist) ---------------------------
 
 
-def test_objectives_passive_verb_is_warning():
+def test_objectives_vague_opener_is_warning():
     body = """\
 :::::: objectives
 - Understand how version control works.
 ::::::
 """
-    findings = _check_objective_verbs(body, "ep.md")
-    assert any("hard-to-assess verb" in f.message for f in findings)
+    findings, count = _check_objective_verbs(body, "ep.md")
+    assert any("hard to assess" in f.message for f in findings)
+    assert count == 1
+
+
+def test_objectives_vague_opener_word_boundary_no_false_positive():
+    # "Knowledgeable"/"Understanding-based" must not match "know"/"understand"
+    # as a bare prefix -- this was a real bug (no \b in the original regex).
+    body = """\
+:::::: objectives
+- Knowledgeable use of Git for version control.
+- Understanding-based approach to Git basics.
+::::::
+"""
+    findings, count = _check_objective_verbs(body, "ep.md")
+    assert findings == []
+    assert count == 2
 
 
 def test_objectives_action_verb_has_no_finding():
@@ -257,7 +272,9 @@ def test_objectives_action_verb_has_no_finding():
 - Explain how version control works.
 ::::::
 """
-    assert _check_objective_verbs(body, "ep.md") == []
+    findings, count = _check_objective_verbs(body, "ep.md")
+    assert findings == []
+    assert count == 1
 
 
 def test_objectives_verb_check_ignores_other_divs():
@@ -268,7 +285,24 @@ def test_objectives_verb_check_ignores_other_divs():
 - Understand this is just an aside.
 ::::::
 """
-    assert _check_objective_verbs(body, "ep.md") == []
+    findings, count = _check_objective_verbs(body, "ep.md")
+    assert findings == []
+    assert count == 0
+
+
+def test_objectives_more_than_four_is_info():
+    body = """\
+:::::: objectives
+- Explain A.
+- Explain B.
+- Explain C.
+- Explain D.
+- Explain E.
+::::::
+"""
+    findings, count = _check_objective_verbs(body, "ep.md")
+    assert count == 5
+    assert any("5 objectives" in f.message for f in findings)
 
 
 # -- style (contractions) ----------------------------------------------------
@@ -283,6 +317,59 @@ def test_contractions_above_threshold_is_info():
     body = "\n".join([f"Line {i}: don't do that, it's not right." for i in range(5)])
     findings = _check_contractions(body, "ep.md")
     assert findings and findings[0].severity == "info"
+
+
+def test_contractions_possessives_are_not_counted():
+    # Real bug: \w+'s matched possessives ("learner's", "Git's") as
+    # contractions. Repeat past the count threshold to isolate the fix.
+    body = "\n".join(
+        [f"Check the learner's laptop and Git's staging area, line {i}." for i in range(5)]
+    )
+    assert _check_contractions(body, "ep.md") == []
+
+
+def test_contractions_curly_apostrophe_is_counted():
+    body = "\n".join([f"Line {i}: don’t do that, it’s not right." for i in range(5)])
+    findings = _check_contractions(body, "ep.md")
+    assert findings and findings[0].severity == "info"
+
+
+# -- objectives assessed by exercises (Carpentries Lab checklist) -----------
+
+
+def test_objectives_with_zero_exercises_is_warning(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    path = lesson_dir / "episodes" / "01-intro.md"
+    path.write_text(
+        episode_text(
+            front_matter="title: 'Ep'\nteaching: 15\nexercises: 0",
+            body=VALID_EPISODE_BODY,
+        )
+    )
+    findings = check_episode(path, lesson_dir)
+    assert any("exercises: 0" in f.message for f in findings)
+
+
+def test_objectives_with_nonzero_exercises_is_silent(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    path = lesson_dir / "episodes" / "01-intro.md"
+    path.write_text(episode_text())  # default fixture has exercises: 15
+    findings = check_episode(path, lesson_dir)
+    assert not any("exercises: 0" in f.message for f in findings)
+
+
+# -- glossary path (Workbench convention) ------------------------------------
+
+
+def test_config_glossary_at_learners_path_is_recognized(tmp_path):
+    # Real bug: the check only looked at lesson_dir/reference.md, but
+    # Workbench's actual convention (confirmed against workbench-template-md
+    # and a real published lesson) is learners/reference.md.
+    lesson_dir = make_lesson(tmp_path)
+    (lesson_dir / "learners").mkdir()
+    (lesson_dir / "learners" / "reference.md").write_text("# Reference\n")
+    findings = check_config(lesson_dir)
+    assert not any("glossary" in f.message for f in findings)
 
 
 # -- end to end -------------------------------------------------------------


### PR DESCRIPTION
## Why this exists as a separate PR

#8 got merged before I'd pushed the adjudication-round fixes -- I kept pushing commits to that branch after it was already merged, so they silently never reached `main`. This PR is just those two orphaned commits, cherry-picked onto current `main`:

- `Fix bugs found by external validation, add CI`
- `Capture adjudication outcome in the design doc`

## What's actually in this PR

Everything described in the external-validation adjudication for #8 that didn't make it in:

- **Glossary path bug** (the important one): the check looked at `lesson_dir/reference.md`, but Workbench's real convention -- confirmed against `workbench-template-md` and `librarycarpentry/lc-git` -- is `learners/reference.md`. `main` right now false-positives "no glossary" on every correctly-structured lesson.
- **Objective-verb word-boundary bug**: `.startswith("know")` matched "Knowledgeable use of Git" and "Understanding-based approach" -- fixed with a proper regex, denylist expanded, finding language softened.
- **Contraction regex bug**: `\w+'s` counted possessives ("learner's", "Git's") as contractions, missed curly apostrophes. Rewrote against a closed set of contractable stems, normalized to a rate per 1,000 words.
- Added the CLDT-verified "2-4 objectives per episode" check and "objectives declared but `exercises: 0`" check.
- Pinned the Carpentries Lab checklist verbatim into the AI review prompt instead of leaving it to retrieval.
- Added `.github/workflows/test.yml` -- `pixi run test` on push/PR.
- Provenance tags (`[CLDT]`, `[Carpentries Lab]`) on every pedagogy-check finding.

Full reasoning and what was verified vs. rejected from the external review: `design/validation-prompt-pedagogy-checks-2026-08-20.md`.

## Test plan

- [x] `pixi run test` -- 35/35 passing
- [x] Clean cherry-pick onto current `main`, no conflicts