### PR TITLE
Rename repo to carpentries-workbench-checker

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: IMLS Tools
+title: Carpentries Workbench Checker
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -15,7 +15,11 @@ authors:
   - given-names: Eric
     family-names: Huang
     affiliation: UCLA DataSquad
-repository-code: 'https://github.com/ucla-imls-open-sci/imls-tools'
+  - given-names: Tim
+    family-names: Dennis
+    affiliation: UCLA Library Data Science Center
+    orcid: 'https://orcid.org/0000-0001-6632-3812'
+repository-code: 'https://github.com/ucla-imls-open-sci/carpentries-workbench-checker'
 abstract: |2
     A pixi-managed lesson checker for Carpentries Workbench lessons: deterministic
     structure checks (front matter, required blocks, headings, links/images) that
@@ -33,4 +37,4 @@ keywords:
   - Python
   - open science
 license: BSD-3-Clause
-commit: 82ce89cc43cd38341ca267faefdf203ef8b185bc
+commit: 8ed897ae14787e20b3b18b9512dd4c22a9846961

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-IMLS Tools
-==========
+Carpentries Workbench Checker
+==============================
 
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 

--- a/checker/ai_review.py
+++ b/checker/ai_review.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import os
 import subprocess
 
-os.environ.setdefault("USER_AGENT", "imls-tools-lesson-checker/0.2")
+os.environ.setdefault("USER_AGENT", "carpentries-workbench-checker/0.2")
 
 from langchain_chroma import Chroma
 from langchain_community.document_loaders import WebBaseLoader
@@ -101,7 +101,7 @@ def _get_retriever(embed_model: str):
         chunks = splitter.split_documents(docs_list)
         vectorstore = Chroma.from_documents(
             documents=chunks,
-            collection_name="imls-tools-style-guide",
+            collection_name="carpentries-workbench-checker-style-guide",
             embedding=OllamaEmbeddings(model=embed_model),
         )
         _RETRIEVER_CACHE[embed_model] = vectorstore.as_retriever()

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -20,7 +20,7 @@ from checker.report import render_html_via_quarto, render_json, render_markdown,
 
 def _resolve_target(target: str) -> tuple[Path, tempfile.TemporaryDirectory | None]:
     if target.startswith(("http://", "https://", "git@")):
-        tmp = tempfile.TemporaryDirectory(prefix="imls-tools-")
+        tmp = tempfile.TemporaryDirectory(prefix="carpentries-workbench-checker-")
         dest = Path(tmp.name) / "lesson"
         result = subprocess.run(
             ["git", "clone", "--quiet", "--depth", "1", target, str(dest)],

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 authors = ["Tim Dennis <tdennis@library.ucla.edu>"]
 channels = ["conda-forge"]
-name = "imls-tools"
+name = "carpentries-workbench-checker"
 platforms = ["osx-arm64", "osx-64", "linux-64"]
 version = "0.1.0"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

The tool stopped being generic "imls-tools" a while ago -- it's specifically a Carpentries Workbench lesson checker now, and the name should say that. GitHub repo already renamed (`imls-tools` -> `carpentries-workbench-checker`, redirects automatically); this PR updates everything inside the repo to match:

- `pixi.toml`'s `name`
- README title
- `CITATION.cff`: title, `repository-code` URL, and added Tim Dennis as an author (ORCID)
- Internal string references: temp-dir prefix, `USER_AGENT`, Chroma collection name

Left the two `design/` validation-prompt docs referencing the old name alone -- they're point-in-time records of a specific review round, not living documentation that should track the current name.

## Test plan

- [x] `pixi run test` -- 35/35 passing (reinstalled the pixi env after the local directory move, since it bakes in absolute paths)
- [x] Confirmed `git push` against the renamed GitHub URL works (redirect/rename fully in effect)