### PR TITLE
Fix line numbers and code-fence blindness in link checking

### DIFF
--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -383,7 +383,7 @@ def _check_contractions(body: str, location: str) -> list[Finding]:
     return []
 
 
-def _check_divs(body: str, location: str) -> list[Finding]:
+def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]:
     findings = []
     stack: list[tuple[str, int]] = []
     seen_top_level: set[str] = set()
@@ -406,7 +406,7 @@ def _check_divs(body: str, location: str) -> list[Finding]:
                     Finding(
                         "info",
                         "divs",
-                        f"unrecognized div type `{div_type}` on line {lineno}"
+                        f"unrecognized div type `{div_type}` on line {lineno + line_offset}"
                         " -- verify against the Workbench style guide",
                         location=location,
                     )
@@ -417,7 +417,8 @@ def _check_divs(body: str, location: str) -> list[Finding]:
                     Finding(
                         "error",
                         "divs",
-                        f"extraneous closing `:::` on line {lineno} with no matching open div",
+                        f"extraneous closing `:::` on line {lineno + line_offset} with no "
+                        "matching open div",
                         location=location,
                     )
                 )
@@ -429,7 +430,7 @@ def _check_divs(body: str, location: str) -> list[Finding]:
             Finding(
                 "error",
                 "divs",
-                f"`{div_type}` div opened on line {lineno} is never closed",
+                f"`{div_type}` div opened on line {lineno + line_offset} is never closed",
                 location=location,
             )
         )
@@ -448,7 +449,7 @@ def _check_divs(body: str, location: str) -> list[Finding]:
     return findings
 
 
-def _check_headings(body: str, location: str) -> list[Finding]:
+def _check_headings(body: str, location: str, line_offset: int = 0) -> list[Finding]:
     findings = []
     seen: dict[str, int] = {}
     first_heading_seen = False
@@ -461,13 +462,14 @@ def _check_headings(body: str, location: str) -> list[Finding]:
         if not match:
             continue
         level, text = len(match.group(1)), match.group(2).strip()
+        reported_line = lineno + line_offset
 
         if level == 1:
             findings.append(
                 Finding(
                     "error",
                     "headings",
-                    f"level-1 heading `# {text}` on line {lineno}"
+                    f"level-1 heading `# {text}` on line {reported_line}"
                     " -- episodes must not use H1, start at H2",
                     location=location,
                 )
@@ -477,8 +479,8 @@ def _check_headings(body: str, location: str) -> list[Finding]:
                 Finding(
                     "warning",
                     "headings",
-                    f"first heading `{'#' * level} {text}` on line {lineno} is level {level},"
-                    " expected level 2",
+                    f"first heading `{'#' * level} {text}` on line {reported_line} is level "
+                    f"{level}, expected level 2",
                     location=location,
                 )
             )
@@ -491,21 +493,26 @@ def _check_headings(body: str, location: str) -> list[Finding]:
                 Finding(
                     "warning",
                     "headings",
-                    f"heading `{text}` on line {lineno} duplicates the one on line {seen[text]}",
+                    f"heading `{text}` on line {reported_line} duplicates the one on line "
+                    f"{seen[text]}",
                     location=location,
                 )
             )
         else:
-            seen[text] = lineno
+            seen[text] = reported_line
 
     return findings
 
 
-def _check_links(body: str, lesson_dir: Path, location: str) -> list[Finding]:
+def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 0) -> list[Finding]:
     findings = []
     episode_dir = (lesson_dir / "episodes") if (lesson_dir / "episodes").exists() else lesson_dir
+    in_code = _code_fence_mask(body)
 
-    for lineno, line in enumerate(body.splitlines(), start=1):
+    for i, line in enumerate(body.splitlines()):
+        if in_code[i]:
+            continue
+        lineno = i + 1 + line_offset
         for alt, path in IMAGE_RE.findall(line):
             if not alt.strip():
                 findings.append(
@@ -585,13 +592,19 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
         )
         body = text
         front_matter = {}
+        line_offset = 0
     else:
         front_matter, body = parsed
         findings.extend(_check_front_matter(front_matter, location))
+        # Every check below reports line numbers relative to `body`, which
+        # starts after the front matter -- offset them back to real file
+        # line numbers, or every reported line is wrong by the front
+        # matter's length.
+        line_offset = text[: len(text) - len(body)].count("\n")
 
-    findings.extend(_check_divs(body, location))
-    findings.extend(_check_headings(body, location))
-    findings.extend(_check_links(body, lesson_dir, location))
+    findings.extend(_check_divs(body, location, line_offset))
+    findings.extend(_check_headings(body, location, line_offset))
+    findings.extend(_check_links(body, lesson_dir, location, line_offset))
     objective_findings, objective_count = _check_objective_verbs(body, location)
     findings.extend(objective_findings)
     findings.extend(_check_contractions(body, location))

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -231,6 +231,23 @@ def test_links_html_target_resolves_against_md_source(tmp_path):
     assert not any("may be broken" in f.message for f in findings)
 
 
+def test_links_inside_code_fence_are_ignored(tmp_path):
+    # Real bug: a lesson showing learners example markdown to paste into
+    # their own README (e.g. a LICENSE badge link) had that illustrative
+    # link checked as if it were live prose, and flagged as broken.
+    lesson_dir = make_lesson(tmp_path)
+    body = "Add this to your README:\n```markdown\nSee the [LICENSE](LICENSE) file.\n```\n"
+    findings = _check_links(body, lesson_dir, "episodes/ep.md")
+    assert findings == []
+
+
+def test_links_line_offset_is_applied(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    body = "para\n\n![](fig/missing.png)\n"
+    findings = _check_links(body, lesson_dir, "episodes/ep.md", line_offset=5)
+    assert any("line 8" in f.message for f in findings)  # body line 3 + offset 5
+
+
 def test_links_generic_link_text_is_warning(tmp_path):
     lesson_dir = make_lesson(tmp_path)
     body = "Read more [here](https://example.org/docs).\n"
@@ -380,3 +397,21 @@ def test_check_episode_end_to_end_valid_episode_has_no_findings(tmp_path):
     path = lesson_dir / "episodes" / "01-intro.md"
     path.write_text(episode_text())
     assert check_episode(path, lesson_dir) == []
+
+
+def test_check_episode_reports_real_file_line_numbers_not_body_relative(tmp_path):
+    # Real bug: every check operated on `body` (text after the front-matter
+    # strip) but reported line numbers as if body started at line 1, so
+    # every finding's line number was off by the front matter's length.
+    lesson_dir = make_lesson(tmp_path)
+    path = lesson_dir / "episodes" / "01-intro.md"
+    # A level-1 heading is always an error, regardless of position -- unlike
+    # a bare H3, which is only flagged if it's the *first* heading.
+    full_text = episode_text(body=VALID_EPISODE_BODY + "\n# Stray H1\n")
+    path.write_text(full_text)
+    real_line = full_text.count("\n", 0, full_text.index("# Stray H1")) + 1
+
+    findings = check_episode(path, lesson_dir)
+    heading_findings = [f for f in findings if "Stray H1" in f.message]
+    assert heading_findings, "expected a level-1 heading finding"
+    assert f"line {real_line}" in heading_findings[0].message


### PR DESCRIPTION
## Summary

Found both while spot-checking a finding against the real file (`research-software-citable-discoverable`, at `~/projects/lessons/content/`):

- **Line numbers were wrong by the front-matter's length.** Every div/heading/link check operated on `body` (text after the front-matter strip) but reported line numbers as if `body` started at line 1. A reported "line 273" was actually line 278 in the file. Threaded a `line_offset` through `_check_divs`/`_check_headings`/`_check_links`, computed once in `check_episode` from where `body` actually starts in the original text.
- **`_check_links` never skipped fenced code blocks**, unlike every other check (`_check_divs`/`_check_headings`/`_check_contractions` all already did this). A lesson showing learners example markdown to paste into their own README (a `[LICENSE](LICENSE)` link inside a ` ```markdown ` block) got that illustrative link checked as live prose and flagged as broken.

Together these produced a real false-positive: "internal link on line 273 may be broken: `LICENSE`" -- the line was wrong *and* the link was inside a code example, not real prose.

## Test plan

- [x] `pixi run test` -- 38/38 passing (3 new regression tests)
- [x] Re-ran against `research-software-citable-discoverable`: the false positive is gone, and spot-checked a real remaining finding (`managing-environments-pixi.md` line 27) against the actual file with `sed -n '27p'` -- matches exactly