### PR TITLE
Add CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,159 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the
+dignity, rights, and contributions of all individuals, regardless of
+characteristics including race, ethnicity, caste, color, age, physical
+characteristics, neurodiversity, disability, sex or gender, gender identity
+or expression, sexual orientation, language, philosophy or religion,
+national or social origin, socio-economic position, level of education, or
+other status. The same privileges of participation are extended to everyone
+who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our
+community's expectations for positive behavior. We also understand that our
+words and actions may be interpreted differently than we intend based on
+culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each
+other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways
+   of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our
+   community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances,
+threats, and promotion of these behaviors are violations of this Code of
+Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in
+   unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative
+   comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality
+   or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered
+   inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or
+   private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other
+   harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or
+   pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of
+   content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content
+   in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content
+   which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying
+their best to collaborate. Not every conflict represents a code of conduct
+violation, and this Code of Conduct reinforces encouraged behaviors and
+norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To
+report a possible violation, email
+[Tim Dennis](mailto:tdennis@library.ucla.edu), the project maintainer.
+
+This is currently a small, solo-maintained project rather than a project
+with a dedicated moderation team — reports will still be taken seriously and
+handled with the same care described below, investigated and enforced by
+the maintainer(s) directly.
+
+## Addressing and Repairing Harm
+
+If an investigation finds that this Code of Conduct has been violated, the
+following enforcement ladder may be used to determine how best to repair
+harm, based on the incident's impact on the individuals involved and the
+community as a whole. Depending on the severity of a violation, lower rungs
+on the ladder may be skipped.
+
+1. Warning
+   1. Event: A violation involving a single incident or series of incidents.
+   2. Consequence: A private, written warning from the maintainer(s).
+   3. Repair: Examples of repair include a private written apology,
+      acknowledgement of responsibility, and seeking clarification on
+      expectations.
+2. Temporarily Limited Activities
+   1. Event: A repeated incidence of a violation that previously resulted in
+      a warning, or the first incidence of a more serious violation.
+   2. Consequence: A private, written warning with a time-limited cooldown
+      period designed to underscore the seriousness of the situation and
+      give the community members involved time to process the incident.
+      The cooldown period may be limited to particular communication
+      channels or interactions with particular community members.
+   3. Repair: Examples of repair may include making an apology, using the
+      cooldown period to reflect on actions and impact, and being
+      thoughtful about re-entering community spaces after the period is
+      over.
+3. Temporary Suspension
+   1. Event: A pattern of repeated violation which the maintainer(s) have
+      tried to address with warnings, or a single serious violation.
+   2. Consequence: A private written warning with conditions for return
+      from suspension. In general, temporary suspensions give the person
+      being suspended time to reflect upon their behavior and possible
+      corrective actions.
+   3. Repair: Examples of repair include respecting the spirit of the
+      suspension, meeting the specified conditions for return, and being
+      thoughtful about how to reintegrate with the community when the
+      suspension is lifted.
+4. Permanent Ban
+   1. Event: A pattern of repeated code of conduct violations that other
+      steps on the ladder have failed to resolve, or a violation so serious
+      that the maintainer(s) determine there is no way to keep the
+      community safe with this person as a member.
+   2. Consequence: Access to all community spaces, tools, and communication
+      channels is removed. In general, permanent bans should be rarely
+      used, should have strong reasoning behind them, and should only be
+      resorted to if working through other remedies has failed to change
+      the behavior.
+   3. Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the
+ability of the maintainer(s) to use their discretion and judgment, in
+keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (this repository's
+issues, pull requests, and discussions), and also applies when an
+individual is officially representing the community in public or other
+spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0,
+permanently available at
+[https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/),
+via the [UC OSPO Network's template](https://github.com/UC-OSPO-Network/templates).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and
+licensed under CC BY-SA 4.0. To view a copy of this license, visit
+[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).
+
+For answers to common questions about Contributor Covenant, see the FAQ at
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
+Translations are provided at
+[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+The enforcement ladder was inspired by the work of
+[Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for your interest in `carpentries-workbench-checker`! This is a small
+tool maintained within the UCLA Library IMLS Open Science program (part of
+the [UC OSPO Network](https://ucospo.net)) — currently solo-maintained, so
+process here is intentionally lightweight.
+
+## Ways to Contribute
+
+- Bug reports and fixes, especially false positives/negatives against real
+  Carpentries Workbench lessons
+- New checks, grounded in an actual source (`sandpaper`/`pegboard`'s real
+  validation rules, the Carpentries style guide, [Collaborative Lesson
+  Development Training](https://carpentries.github.io/lesson-development-training/aio.html),
+  or [The Carpentries Lab's reviewer checklist](https://github.com/carpentries-lab/reviews/blob/main/docs/reviewer_guide.md))
+  — please cite the source in the PR, and tag the finding's hint text
+  (`[CLDT]`, `[Carpentries Lab]`, etc.) so it's clear what's an official
+  Workbench rule vs. a local heuristic
+- Documentation fixes
+
+## Finding Something to Work On
+
+No formal issue triage process yet — check the
+[Issues tab](https://github.com/ucla-imls-open-sci/carpentries-workbench-checker/issues),
+or open a new one if you've found a problem or have an idea.
+
+## Setting Up a Dev Environment
+
+```bash
+git clone https://github.com/ucla-imls-open-sci/carpentries-workbench-checker.git
+cd carpentries-workbench-checker
+pixi install
+```
+
+See the [README](README.md) for the full setup and usage reference.
+
+## Running Tests
+
+```bash
+pixi run test
+```
+
+Covers the mechanical checks (`checker/lesson_check.py`) — no network access
+or local models needed. If you're changing behavior in `checker/lesson_check.py`,
+add a regression test alongside the fix; several existing tests exist
+specifically because a real lesson surfaced a bug the synthetic cases
+missed (see commit history for examples).
+
+The AI review layer (`checker/ai_review.py`) isn't covered by automated
+tests since it calls live models — changes there should be manually
+smoke-tested against a real lesson before opening a PR.
+
+## Commit Norms
+
+No enforced format — clear, descriptive commit messages are enough. If a
+commit fixes a bug found by testing against a real lesson, say which lesson
+and what the actual wrong output was; that context is more useful than the
+diff alone.
+
+## Pull Requests
+
+Branch off `main`, open a PR against it — direct pushes to `main` aren't
+used here. Include what you tested and how (which lesson, what the
+before/after output looked like) in the PR description; "trust me" isn't
+enough for a tool whose whole job is producing trustworthy findings.
+
+## Code of Conduct
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ the OpenAI API) is unrelated to lesson checking and untouched here — it
 still uses the legacy `openai.Completion.create` API and could use its own
 pass at some point.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Everyone participating is expected
+to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## License
 
 [BSD 3-Clause](LICENSE)


### PR DESCRIPTION
## Summary

Rounds out the [UC OSPO Network's expected core files](https://ucospo.net/oss-resources/) (README, Contributing, Code of Conduct, License, Citation) — this repo already had README/LICENSE/CITATION.cff.

Both adapted from the OSPO Network's official templates ([UC-OSPO-Network/templates](https://github.com/UC-OSPO-Network/templates)), not pasted verbatim:

- **CODE_OF_CONDUCT.md** keeps the Contributor Covenant v3.0 text close to as-is (it's a standard, not something to customize much) — filled in the reporting contact (maintainer's email) and reframed "Community Moderators" as "the maintainer(s)" to match reality (small, solo-maintained project, not a project with a moderation team).
- **CONTRIBUTING.md** drops the template sections that don't apply here (community calls, PR-review SLAs, release-cadence promises, mandatory Conventional Commits/signed commits) rather than leaving boilerplate that overpromises process this project doesn't have. Kept: ways to contribute, dev setup (pixi), testing, and a note that check additions should cite their source (sandpaper/pegboard, CLDT, Lab checklist) and use the `[CLDT]`/`[Carpentries Lab]` provenance-tag convention already used in the finding hints.

Linked both from the README.

## Test plan

N/A — documentation only, no code changed.