### PR TITLE
Fix truncated/empty AI reviews (max_tokens too low)

### DIFF
--- a/checker/ai_review.py
+++ b/checker/ai_review.py
@@ -190,11 +190,23 @@ def _check_with_claude(prompt: str, model: str) -> str:
         kwargs["output_config"] = {"effort": "high"}
     response = client.messages.create(
         model=model,
-        max_tokens=4096,
+        # 4096 was too low: extended thinking (on by default at effort=high)
+        # shares this same budget with the visible response, so a thorough
+        # review could burn the whole cap on thinking and return empty text,
+        # or get cut off mid-sentence. 16000 is Anthropic's own recommended
+        # non-streaming default -- high enough to avoid that, not so high it
+        # risks the SDK's non-streaming HTTP timeout.
+        max_tokens=16000,
         messages=[{"role": "user", "content": prompt}],
         **kwargs,
     )
-    return "".join(block.text for block in response.content if block.type == "text")
+    text = "".join(block.text for block in response.content if block.type == "text")
+    if response.stop_reason == "max_tokens":
+        text += (
+            "\n\n[review truncated -- hit the 16000-token output cap. If this "
+            "keeps happening, that's worth raising as an issue.]"
+        )
+    return text
 
 
 CODEX_TIMEOUT_SECONDS = 300


### PR DESCRIPTION
## Summary

Caught live: running \`--ai --backend claude\` against an 8-episode lesson, one episode's review came back completely empty and several others cut off mid-sentence.

Root cause: \`max_tokens=4096\`, and extended thinking (on by default at \`effort=high\`, which we already set for Opus/Sonnet) shares that same budget with the visible response. A thorough review could burn the whole cap on thinking alone and return zero text, or get cut off partway through -- and these got noticeably more thorough once the Lab checklist was pinned into the prompt.

- Bumped to 16000 (Anthropic's own recommended non-streaming default)
- Added a \`stop_reason == "max_tokens"\` check that appends a visible truncation note instead of silently returning cut-off text, if it ever happens again

## Test plan

- [x] \`pixi run test\` -- 38/38 (no unit test added; this is live-model behavior, matches the project's existing convention that \`ai_review.py\` isn't unit-tested)
- [x] Re-ran against the exact episode that came back empty (\`adding-citation-file.md\`, \`research-software-citable-discoverable\`) -- full, complete review now, no truncation marker