### PR TITLE
Add boilerplate/placeholder detection, backfill actionable hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ the same rules locally, in under a second, with no dependencies beyond
 Python: required front matter (`title`, `teaching`, `exercises`), the three
 required top-level blocks (`questions`, `objectives`, `keypoints`), balanced
 and recognized `:::` div types, heading rules (start at `##`, no `#`, no
-duplicates), and broken internal links/images (including the
+duplicates), broken internal links/images (including the
 `episodes/fig/`-relative image convention Workbench actually uses, and the
-fact that `.html` links point at rendered `.md` sources, not literal files).
+fact that `.html` links point at rendered `.md` sources, not literal files),
+and whether an episode (or `learners/setup.md`, `instructors/instructor-notes.md`,
+`profiles/learner-profiles.md`) is still the unedited scaffold Sandpaper
+generated, structurally complete but never actually written.
 
 None of that requires a model. The AI layer (`checker/ai_review.py`) is for
 the part a deterministic checker can't do: whether a challenge is
@@ -120,13 +123,14 @@ throughput long before you run out of RAM outright.
 
 | Category | What we check | Mirrors |
 |---|---|---|
-| `config` | Placeholder values left unfilled, `created` date, episode list vs. files on disk | `sandpaper::validate_lesson()` |
+| `config` | Placeholder values left unfilled, `created` date, episode list vs. files on disk, episode files under `episodes/` with no `.md`/`.Rmd` extension (invisible to both Sandpaper and this checker's own glob otherwise) | `sandpaper::validate_lesson()` |
 | `front-matter` | `title` / `teaching` / `exercises` present and numeric, episode length (`teaching`+`exercises`) roughly 20–60 min | `sandpaper::validate_lesson()`, [CLDT episode scope guidance](https://carpentries.github.io/lesson-development-training/aio.html) |
 | `divs` | Required `questions`/`objectives`/`keypoints`, balanced `:::` fences, recognized div types, challenge/solution counts | `pegboard::validate_divs()` |
 | `headings` | First heading is `##`, no `#`, no duplicate headings | `pegboard::validate_headings()` |
 | `links` | Missing alt text, broken internal links/images (including `episodes/fig/`-relative images and `.html`→`.md` resolution), generic link text (`"click here"`) | `pegboard::validate_links()`, [Carpentries Lab reviewer checklist](https://github.com/carpentries-lab/reviews/blob/main/docs/reviewer_guide.md) |
 | `objectives` | Weak/unmeasurable objective verbs (`know`, `understand`, `appreciate`, ...) vs. action verbs (`explain`, `choose`, `predict`, ...) | CLDT's SMART objectives guidance |
 | `style` | Heavy contraction use | Carpentries Lab reviewer checklist (accessibility, translation/ESL learners) |
+| `boilerplate` | Unedited `sandpaper::create_lesson()` scaffold left in place: an episode's title or body still the generated default, or a `questions`/`objectives`/`keypoints` block that exists but only holds placeholder bullets (`keypoint1`, `Put questions here`, ...); same idea applied to `learners/setup.md`, `learners/reference.md`, `instructors/instructor-notes.md`, `profiles/learner-profiles.md`, which the checks above never look at since they aren't episodes | CLDT, a structurally-complete episode (passes every check above) can still be entirely unwritten, this is the gap between "the required blocks exist" and "someone wrote the lesson" |
 | `config` | *(also)* missing lesson glossary (`reference.md`) | Carpentries Lab reviewer checklist |
 
 Div and heading checks skip content inside fenced code blocks (```` ``` ````/`~~~`) — a lesson that teaches Markdown, Workbench syntax, or shell `#` comments will contain literal `:::`/`#` text that isn't a real div or heading.

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -44,6 +44,65 @@ CONFIG_PLACEHOLDER_VALUES = {
     "source": "https://github.com/carpentries/workbench-template-md",
 }
 
+# Exact strings from `sandpaper::create_lesson()`'s default scaffold episode.
+# A CLDT cohort under deadline pressure regularly ships these unedited -- they
+# read as "done" (all three required blocks are present, front matter is
+# valid) but the content is still the template's own worked example, not the
+# lesson's. Deterministic and exact-match on purpose: this only fires on the
+# literal scaffold text, never on a real episode that happens to share a
+# word with it.
+SCAFFOLD_EPISODE_TITLE = "using markdown"
+SCAFFOLD_BODY_FINGERPRINTS = (
+    "this is a lesson created via the carpentries workbench",
+    'paste("this", "new", "lesson", "looks", "good")',
+    "buoyant barnacle",
+)
+
+# Placeholder bullet text left in required blocks after generating a lesson --
+# the block itself exists (so check_divs is silent), but nothing inside it is
+# real content yet. Matched against a bullet's full text, lowercased and
+# stripped, so "Keypoint 1" and "keypoint1" both match.
+PLACEHOLDER_BULLET_TEXTS = {
+    "keypoint1",
+    "keypoint2",
+    "keypoint 1",
+    "keypoint 2",
+    "objective 1",
+    "objective n",
+    "put questions here",
+    "put objectives here",
+    "put keypoints here",
+}
+
+# Scaffold text in learners/instructors/profiles files -- these aren't
+# episodes, so check_episode() never sees them, and check_config() only
+# checks that learners/reference.md *exists*. A CLDT-produced repo commonly
+# has all of these still at their generated defaults.
+SUPPORT_FILE_CHECKS = {
+    "learners/reference.md": (
+        "this is a placeholder file",
+        "[Carpentries Lab] 'No key terms are missing from the lesson glossary' is part of "
+        "the reviewer checklist. Port over the terms your episodes actually use.",
+    ),
+    "learners/setup.md": (
+        "fixme: setup instructions live in this document",
+        "[CLDT] Covered in the 'Preparing to Teach' episode's Setup Instructions exercise. "
+        "If your lesson needs no software/data setup, replace this with a short note saying "
+        "so, rather than leaving the scaffold's example instructions in place.",
+    ),
+    "instructors/instructor-notes.md": (
+        "this is a placeholder file",
+        "[CLDT] Covered in the 'Preparing to Teach' episode's Instructor Notes exercise: "
+        "rationale, what worked/didn't in early drafts, teaching tips, common "
+        "troubleshooting.",
+    ),
+    "profiles/learner-profiles.md": (
+        "this is a placeholder file",
+        "Add at least one realistic learner profile, used to sanity-check exercise "
+        "difficulty against your stated audience.",
+    ),
+}
+
 # Collaborative Lesson Development Training (carpentries.github.io/lesson-development-training)
 # and The Carpentries Lab reviewer checklist (github.com/carpentries-lab/reviews) both call out
 # weak, unmeasurable objective verbs -- prefer "explain"/"choose"/"predict" over these. This is
@@ -185,8 +244,35 @@ def check_config(lesson_dir: Path) -> list[Finding]:
                 "config",
                 f"config.yaml lists episode `{name}` but it does not exist under episodes/",
                 location="config.yaml",
+                hint="Create the file, or remove it from `episodes:` if it's no longer "
+                "planned.",
             )
         )
+
+    # A file sitting in episodes/ without a .md/.Rmd extension is invisible to
+    # both Sandpaper and this checker's own glob() elsewhere -- it silently
+    # never gets built, never gets checked, and never shows up as "missing"
+    # anywhere else, since nothing ever looked for it. This is exactly what
+    # happened to a real draft episode: renamed with a typo, dropped its
+    # extension, and sat unbuilt and uninspected for days before anyone
+    # noticed. `fig/`, `data/`, and dotfiles are legitimate non-episode
+    # entries and are excluded.
+    if episodes_dir.exists():
+        for p in sorted(episodes_dir.glob("*")):
+            if p.is_dir() or p.name.startswith("."):
+                continue
+            if p.suffix not in (".md", ".Rmd"):
+                findings.append(
+                    Finding(
+                        "warning",
+                        "config",
+                        f"episodes/{p.name} has no .md/.Rmd extension, Sandpaper won't "
+                        "build it and this checker can't inspect it",
+                        location="config.yaml",
+                        hint="If this is meant to be an episode, rename it with a .md "
+                        "extension. Right now it's invisible to the build.",
+                    )
+                )
 
     # A blank `episodes:` field is valid and documented: sandpaper then includes
     # every file under episodes/ automatically, in alphabetical order. Only flag
@@ -227,6 +313,31 @@ def check_config(lesson_dir: Path) -> list[Finding]:
     return findings
 
 
+def check_support_files(lesson_dir: Path) -> list[Finding]:
+    """Check learners/, instructors/, and profiles/ content -- files
+    check_episode() never sees (they aren't episodes) and check_config()
+    only checks for existence of, not content. A CLDT-produced repo commonly
+    has all of these still at their `sandpaper::create_lesson()` defaults,
+    each of these files being generated as a valid, present, entirely
+    unwritten placeholder."""
+    findings = []
+    for rel_path, (fingerprint, hint) in SUPPORT_FILE_CHECKS.items():
+        path = lesson_dir / rel_path
+        if not path.exists():
+            continue
+        if fingerprint in path.read_text(errors="replace").lower():
+            findings.append(
+                Finding(
+                    "warning",
+                    "boilerplate",
+                    f"{rel_path} is still the scaffold placeholder, not written yet",
+                    location=rel_path,
+                    hint=hint,
+                )
+            )
+    return findings
+
+
 def _split_front_matter(text: str) -> tuple[dict, str] | None:
     match = FRONT_MATTER_RE.match(text)
     if not match:
@@ -238,16 +349,31 @@ def _split_front_matter(text: str) -> tuple[dict, str] | None:
     return front_matter, match.group(2)
 
 
+# Real bug found in a CLDT-produced lesson: `exercise:` (singular) instead
+# of `exercises:` silently passes YAML parsing and just looks like a missing
+# field, with no indication the author actually wrote a value, just under
+# the wrong key. Worth naming directly rather than making the author guess.
+_SINGULAR_FIELD_TYPOS = {"exercises": "exercise"}
+
+
 def _check_front_matter(front_matter: dict, location: str) -> list[Finding]:
     findings = []
     for field in ("title", "teaching", "exercises"):
         if field not in front_matter or front_matter[field] in (None, ""):
+            typo = _SINGULAR_FIELD_TYPOS.get(field)
+            hint = f"Add `{field}:` to the YAML front matter."
+            if typo and typo in front_matter:
+                hint = (
+                    f"Found `{typo}:` instead, that's likely a typo, the required "
+                    f"field is `{field}:` (plural)."
+                )
             findings.append(
                 Finding(
                     "error",
                     "front-matter",
                     f"missing required front-matter field `{field}`",
                     location=location,
+                    hint=hint,
                 )
             )
     for field in ("teaching", "exercises"):
@@ -259,6 +385,8 @@ def _check_front_matter(front_matter: dict, location: str) -> list[Finding]:
                     "front-matter",
                     f"`{field}` should be a number of minutes, got {value!r}",
                     location=location,
+                    hint=f"Set `{field}:` to a plain integer, e.g. `{field}: 15`, not a "
+                    "quoted string or a range.",
                 )
             )
 
@@ -348,6 +476,95 @@ def _check_objective_verbs(body: str, location: str) -> tuple[list[Finding], int
     return findings, objective_count
 
 
+def _check_boilerplate(front_matter: dict, body: str, location: str) -> list[Finding]:
+    """Flag unedited `sandpaper::create_lesson()` scaffold content. The three
+    required blocks all being present (so `_check_divs` is silent) says
+    nothing about whether anyone has actually written the episode yet -- a
+    CLDT cohort under time pressure regularly ships the scaffold's own worked
+    example untouched. Exact substring match on purpose, to avoid flagging
+    real content that happens to share incidental wording."""
+    findings = []
+    title = str(front_matter.get("title") or "").strip().lower()
+    if title == SCAFFOLD_EPISODE_TITLE:
+        findings.append(
+            Finding(
+                "error",
+                "boilerplate",
+                f'title is still the scaffold default: "{front_matter.get("title")}"',
+                location=location,
+                hint="[CLDT] This is `sandpaper::create_lesson()`'s own default episode "
+                "title, not a real one. Replace it before this episode is considered "
+                "written.",
+            )
+        )
+
+    body_lower = body.lower()
+    for fingerprint in SCAFFOLD_BODY_FINGERPRINTS:
+        if fingerprint in body_lower:
+            findings.append(
+                Finding(
+                    "warning",
+                    "boilerplate",
+                    f'body still contains scaffold example text: "{fingerprint}"',
+                    location=location,
+                    hint="[CLDT] This looks like unedited Carpentries Workbench scaffold "
+                    "content, not real lesson material. Replace it, or delete the episode "
+                    "if it isn't ready to write yet, an empty episode is more honest than "
+                    "a filled-in-looking one that's still the template.",
+                )
+            )
+    return findings
+
+
+def _check_placeholder_bullets(body: str, location: str) -> list[Finding]:
+    """Flag placeholder bullet text (`keypoint1`, `Put questions here`, ...)
+    left inside `questions`/`objectives`/`keypoints` blocks. The block itself
+    existing satisfies `_check_divs`'s required-block check, so this is the
+    only thing that catches "structurally complete, actually empty"."""
+    findings = []
+    in_code = _code_fence_mask(body)
+    lines = body.splitlines()
+    depth = 0
+    tracked_type: str | None = None
+    tracked_depth: int | None = None
+
+    for i, line in enumerate(lines):
+        if in_code[i]:
+            continue
+        match = DIV_FENCE_RE.match(line.strip())
+        if match:
+            div_type = match.group(2).lower()
+            if div_type:
+                if div_type in REQUIRED_TOP_DIVS and depth == 0:
+                    tracked_type = div_type
+                    tracked_depth = depth
+                depth += 1
+            else:
+                depth -= 1
+                if tracked_type is not None and depth == tracked_depth:
+                    tracked_type = None
+            continue
+
+        if tracked_type is None:
+            continue
+        stripped = line.strip()
+        if not stripped.startswith(("-", "*")):
+            continue
+        bullet_text = stripped.lstrip("-* ").strip().lower()
+        if bullet_text in PLACEHOLDER_BULLET_TEXTS:
+            findings.append(
+                Finding(
+                    "error",
+                    "boilerplate",
+                    f'`{tracked_type}` still has placeholder bullet text: "{stripped.lstrip("-* ").strip()}"',
+                    location=location,
+                    hint="[CLDT] Replace with real content, this is scaffold placeholder "
+                    "text, not a written keypoint/objective/question.",
+                )
+            )
+    return findings
+
+
 def _check_contractions(body: str, location: str) -> list[Finding]:
     """The Carpentries Lab reviewer checklist flags heavy contraction use as an
     accessibility concern for translation and ESL learners. Contractions are a
@@ -409,6 +626,8 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                         f"unrecognized div type `{div_type}` on line {lineno + line_offset}"
                         " -- verify against the Workbench style guide",
                         location=location,
+                        hint="See https://carpentries.github.io/sandpaper-docs/episodes.html "
+                        "for the full list of recognized div types.",
                     )
                 )
         else:
@@ -420,6 +639,9 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                         f"extraneous closing `:::` on line {lineno + line_offset} with no "
                         "matching open div",
                         location=location,
+                        hint="Either this fence has no matching opening `::: type` above it, "
+                        "or an earlier div's closing fence was deleted, causing this one to "
+                        "close the wrong block. Check the div immediately above.",
                     )
                 )
             else:
@@ -432,6 +654,11 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                 "divs",
                 f"`{div_type}` div opened on line {lineno + line_offset} is never closed",
                 location=location,
+                hint="Add a closing `:::` fence (same or more colons than the opening "
+                "fence) before the next block starts. An unclosed div silently swallows "
+                "everything after it, including blocks that look fine on their own, "
+                "check whether a `keypoints`/`questions`/`objectives` block further down "
+                "actually landed inside this one instead of at the top level.",
             )
         )
 
@@ -443,6 +670,10 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                     "divs",
                     f"missing required `{required}` block",
                     location=location,
+                    hint=f"Every episode needs a top-level `:::: {required} ... ::::` block. "
+                    "If one exists in the file but isn't showing as top-level, an earlier "
+                    "unclosed div is probably nesting it, see any 'never closed' finding "
+                    "above first.",
                 )
             )
 
@@ -536,6 +767,9 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                             "links",
                             f"image on line {lineno} points to a missing file: `{path}`",
                             location=location,
+                            hint="Check the path is relative to episodes/ (images "
+                            "typically live in episodes/fig/), and that the file was "
+                            "actually committed.",
                         )
                     )
 
@@ -570,6 +804,9 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                         "links",
                         f"internal link on line {lineno} may be broken: `{path}`",
                         location=location,
+                        hint="Confirm the target exists relative to episodes/, the "
+                        "lesson root, or learners/, instructors/, profiles/. A link to "
+                        "another episode's rendered .html targets its .md source.",
                     )
                 )
     return findings
@@ -605,6 +842,8 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
     findings.extend(_check_divs(body, location, line_offset))
     findings.extend(_check_headings(body, location, line_offset))
     findings.extend(_check_links(body, lesson_dir, location, line_offset))
+    findings.extend(_check_boilerplate(front_matter, body, location))
+    findings.extend(_check_placeholder_bullets(body, location))
     objective_findings, objective_count = _check_objective_verbs(body, location)
     findings.extend(objective_findings)
     findings.extend(_check_contractions(body, location))
@@ -652,6 +891,7 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
 
 def run_checks(lesson_dir: Path, episode_filter: str | None = None) -> list[Finding]:
     findings = check_config(lesson_dir)
+    findings.extend(check_support_files(lesson_dir))
 
     episodes_dir = lesson_dir / "episodes"
     if not episodes_dir.exists():

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -12,14 +12,17 @@ from __future__ import annotations
 from pathlib import Path
 
 from checker.lesson_check import (
+    _check_boilerplate,
     _check_contractions,
     _check_divs,
     _check_front_matter,
     _check_headings,
     _check_links,
     _check_objective_verbs,
+    _check_placeholder_bullets,
     check_config,
     check_episode,
+    check_support_files,
 )
 
 VALID_EPISODE_BODY = """\
@@ -387,6 +390,160 @@ def test_config_glossary_at_learners_path_is_recognized(tmp_path):
     (lesson_dir / "learners" / "reference.md").write_text("# Reference\n")
     findings = check_config(lesson_dir)
     assert not any("glossary" in f.message for f in findings)
+
+
+# -- boilerplate / placeholder detection (CLDT: catch unedited scaffold) ----
+# Real bugs found auditing a live CLDT cohort's lesson repo the week after
+# training: episodes left at the scaffold's own title/body, and required
+# blocks present but still holding the scaffold's placeholder bullets.
+
+
+def test_boilerplate_scaffold_title_is_error():
+    findings = _check_boilerplate({"title": "Using Markdown"}, "Some real body.", "ep.md")
+    assert any(f.severity == "error" and "scaffold default" in f.message for f in findings)
+
+
+def test_boilerplate_real_title_is_silent():
+    findings = _check_boilerplate({"title": "Why License?"}, "Some real body.", "ep.md")
+    assert findings == []
+
+
+def test_boilerplate_scaffold_body_fingerprint_is_warning():
+    body = 'Some intro.\n\n```r\npaste("This", "new", "lesson", "looks", "good")\n```\n'
+    findings = _check_boilerplate({"title": "Real Title"}, body, "ep.md")
+    assert any(f.severity == "warning" and "scaffold example text" in f.message for f in findings)
+
+
+def test_boilerplate_real_body_is_silent():
+    findings = _check_boilerplate(
+        {"title": "Real Title"}, "This episode explains real licensing content.", "ep.md"
+    )
+    assert findings == []
+
+
+def test_placeholder_bullets_keypoint_variants_are_flagged():
+    body = """\
+:::::: keypoints
+- keypoint1
+- keypoint 2
+::::::
+"""
+    findings = _check_placeholder_bullets(body, "ep.md")
+    assert len(findings) == 2
+    assert all(f.severity == "error" for f in findings)
+
+
+def test_placeholder_bullets_real_keypoint_is_silent():
+    body = """\
+:::::: keypoints
+- A license does not give away ownership of your code.
+::::::
+"""
+    assert _check_placeholder_bullets(body, "ep.md") == []
+
+
+def test_placeholder_bullets_only_checked_inside_required_blocks():
+    # A challenge/solution bullet that happens to read "objective 1" (e.g. a
+    # multiple-choice answer option) must not be flagged -- only the actual
+    # questions/objectives/keypoints blocks are in scope.
+    body = """\
+:::::: challenge
+- objective 1
+::::::
+"""
+    assert _check_placeholder_bullets(body, "ep.md") == []
+
+
+# -- extension-less episode files (CLDT: catch invisible-to-the-build files) -
+
+
+def test_config_extension_less_episode_file_is_warning(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    # No .md/.Rmd extension -- Sandpaper's glob (and this checker's own
+    # elsewhere) silently excludes it, so nothing else would ever flag it.
+    (lesson_dir / "episodes" / "episode-2-permissive-vs-copyleft").write_text(episode_text())
+    findings = check_config(lesson_dir)
+    assert any(
+        f.severity == "warning" and "no .md/.Rmd extension" in f.message for f in findings
+    )
+
+
+def test_config_fig_and_data_dirs_are_not_flagged(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    (lesson_dir / "episodes" / "fig").mkdir()
+    (lesson_dir / "episodes" / "fig" / "diagram.png").write_bytes(b"")
+    findings = check_config(lesson_dir)
+    assert not any("no .md/.Rmd extension" in f.message for f in findings)
+
+
+# -- support files: learners/, instructors/, profiles/ content --------------
+# check_episode() never sees these (they aren't episodes), and check_config()
+# only checked for existence, not content -- real repo had all four of these
+# still at the sandpaper::create_lesson() default.
+
+
+def test_support_files_placeholder_reference_is_warning(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    (lesson_dir / "learners").mkdir()
+    (lesson_dir / "learners" / "reference.md").write_text(
+        "---\ntitle: 'Reference'\n---\n\n## Glossary\n\nThis is a placeholder file. Please add content here.\n"
+    )
+    findings = check_support_files(lesson_dir)
+    assert any("learners/reference.md" in f.location for f in findings)
+
+
+def test_support_files_real_reference_is_silent(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    (lesson_dir / "learners").mkdir()
+    (lesson_dir / "learners" / "reference.md").write_text(
+        "---\ntitle: 'Reference'\n---\n\n## Glossary\n\nPermissive license\n: Allows reuse with minimal restriction.\n"
+    )
+    assert check_support_files(lesson_dir) == []
+
+
+def test_support_files_missing_file_is_not_flagged(tmp_path):
+    # Absence is check_config's job (the existing glossary-file-exists check);
+    # check_support_files only judges content of files that are present.
+    lesson_dir = make_lesson(tmp_path)
+    assert check_support_files(lesson_dir) == []
+
+
+def test_support_files_all_four_paths_checked(tmp_path):
+    lesson_dir = make_lesson(tmp_path)
+    (lesson_dir / "learners").mkdir()
+    (lesson_dir / "instructors").mkdir()
+    (lesson_dir / "profiles").mkdir()
+    (lesson_dir / "learners" / "setup.md").write_text(
+        "---\ntitle: Setup\n---\n\nFIXME: Setup instructions live in this document.\n"
+    )
+    (lesson_dir / "instructors" / "instructor-notes.md").write_text(
+        "---\ntitle: 'Instructor Notes'\n---\n\nThis is a placeholder file. Please add content here.\n"
+    )
+    (lesson_dir / "profiles" / "learner-profiles.md").write_text(
+        "---\ntitle: FIXME\n---\n\nThis is a placeholder file. Please add content here.\n"
+    )
+    findings = check_support_files(lesson_dir)
+    locations = {f.location for f in findings}
+    assert locations == {
+        "learners/setup.md",
+        "instructors/instructor-notes.md",
+        "profiles/learner-profiles.md",
+    }
+
+
+# -- front-matter typo hint (CLDT: exercise: vs exercises:) -----------------
+
+
+def test_front_matter_exercise_typo_gets_specific_hint():
+    findings = _check_front_matter({"title": "Ep", "teaching": 15, "exercise": 10}, "ep.md")
+    missing = [f for f in findings if "exercises" in f.message]
+    assert missing and missing[0].hint and "exercise:" in missing[0].hint
+
+
+def test_front_matter_generic_missing_field_has_generic_hint():
+    findings = _check_front_matter({"teaching": 15, "exercises": 10}, "ep.md")
+    missing = [f for f in findings if "title" in f.message]
+    assert missing and missing[0].hint == "Add `title:` to the YAML front matter."
 
 
 # -- end to end -------------------------------------------------------------


### PR DESCRIPTION
## Summary

Auditing a real CLDT cohort's lesson repo (`UC-OSPO-Network/oss-license-workshop`) the week after training surfaced a real gap: an episode can pass every existing check, valid front matter, all three required blocks present, no broken links, and still be entirely unwritten, still the `sandpaper::create_lesson()` scaffold, or holding literal placeholder text (`keypoint1`, `Put questions here`) inside an otherwise-valid block. None of that was visible before, since block *presence* was all that got checked, never content.

- **New `boilerplate` check**: scaffold title/body fingerprints per episode, plus the same idea applied to `learners/setup.md`, `learners/reference.md`, `instructors/instructor-notes.md`, `profiles/learner-profiles.md`, files the existing episode checks never touch since they aren't episodes.
- **New placeholder-bullet check** inside `questions`/`objectives`/`keypoints` blocks.
- **New warning** for episode files missing a `.md`/`.Rmd` extension. Previously silently excluded from every check, which is exactly how a real draft episode (`episode-2-permissive-vs-copyleft`, no extension) went unbuilt and uninspected for days on an open PR.
- **Backfilled hints** onto several existing findings that had none before (missing front-matter fields, unclosed/extraneous divs, missing required blocks, broken images/links), including naming the `exercise:`/`exercises:` singular-plural typo directly rather than leaving the author to guess why a field they set still reads as missing.

Ran the updated checker against the real `oss-license-workshop` repo as a live test throughout, every new finding maps to a real, verified problem in that repo (see the six issues filed there this week).

## Test plan
- [x] `pixi run test`: 53 passed (38 existing + 15 new)
- [x] Ran against `oss-license-workshop` before and after, confirmed new findings match manually-verified real bugs and no existing findings regressed
- [x] Confirmed the extension-less-file check specifically catches the real PR #5 bug pattern (verified in an isolated temp lesson dir with that draft episode copied in)