### PR TITLE
Add --blame report annotation and AI glossary-gap suggestions

### DIFF
--- a/checker/ai_review.py
+++ b/checker/ai_review.py
@@ -115,12 +115,18 @@ def _style_context(episode_text: str, embed_model: str) -> str:
     return "\n\n---\n\n".join(d.page_content for d in docs)
 
 
-def _build_prompt(episode_text: str, findings: list[Finding], style_context: str) -> str:
+def _build_prompt(
+    episode_text: str, findings: list[Finding], style_context: str, glossary_text: str = ""
+) -> str:
     mechanical_summary = (
         "\n".join(
             f"- [{f.severity}] {f.category}: {f.message}" for f in findings if f.location
         )
         or "(none -- the episode passed all mechanical structure checks)"
+    )
+    glossary_section = (
+        f"Current lesson glossary ({'learners/reference.md' if glossary_text else 'none found, or still the scaffold placeholder'}):\n"
+        f"{glossary_text or '(empty)'}"
     )
     return f"""You are reviewing a Carpentries Workbench lesson episode the way a human
 reviewer for The Carpentries Lab would.
@@ -137,6 +143,8 @@ the checklist above is the grading criteria):
 Mechanical structure issues already found by an automated checker (do not
 repeat these -- focus on what a checker can't catch):
 {mechanical_summary}
+
+{glossary_section}
 
 One of the mechanical checks flags objectives that *open* with a vague verb
 (know/understand/appreciate/...) as a cheap heuristic. Do not treat that as
@@ -167,6 +175,15 @@ checklist above:
    is content well-sequenced with worked examples before exercises?
 5. Tone: dismissive language ("simply", "just"), unstated assumptions, or
    unexplained jargon that would trip up a learner encountering this fresh.
+6. Glossary gaps: list every term of art, acronym, or domain-specific word
+   this episode uses that a learner at the stated audience level couldn't
+   be expected to already know, and that isn't already defined in the
+   glossary shown above. For each, give a one-sentence draft definition
+   scoped to how this lesson actually uses the term, not a generic
+   dictionary definition. Skip a term entirely if the episode already
+   explains it inline, that's not a glossary gap, that's the episode doing
+   its job. Also skip anything already covered in the glossary above, even
+   loosely, don't suggest a near-duplicate entry.
 Keep it concrete -- point at specific lines or phrases, don't just restate
 the checklist above."""
 
@@ -252,10 +269,11 @@ def review_episode(
     backend: str,
     model: str | None,
     embed_model: str = EMBED_MODEL,
+    glossary_text: str = "",
 ) -> str:
     if backend not in BACKENDS:
         raise ValueError(f"unknown backend `{backend}`, expected one of {sorted(BACKENDS)}")
     resolved_model = model or DEFAULT_MODELS[backend]
     style_context = _style_context(episode_text, embed_model)
-    prompt = _build_prompt(episode_text, findings, style_context)
+    prompt = _build_prompt(episode_text, findings, style_context, glossary_text)
     return BACKENDS[backend](prompt, resolved_model)

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -14,7 +14,7 @@ import tempfile
 from pathlib import Path
 
 from checker.ai_review import BACKENDS, review_episode
-from checker.lesson_check import run_checks
+from checker.lesson_check import SUPPORT_FILE_CHECKS, run_checks
 from checker.report import render_html_via_quarto, render_json, render_markdown, render_terminal
 
 
@@ -45,6 +45,44 @@ def _write_or_print(text: str, output: str | None):
         print(text)
 
 
+def _read_glossary(lesson_dir: Path) -> str:
+    """The lesson's learners/reference.md, empty string if missing or still
+    the sandpaper scaffold placeholder -- feeding placeholder text to the AI
+    review as if it were "the current glossary" would make it think existing
+    terms are covered when nothing has actually been written yet."""
+    path = lesson_dir / "learners" / "reference.md"
+    if not path.exists():
+        return ""
+    text = path.read_text(errors="replace")
+    fingerprint, _hint = SUPPORT_FILE_CHECKS["learners/reference.md"]
+    if fingerprint in text.lower():
+        return ""
+    return text
+
+
+def _blame_map(lesson_dir: Path, findings: list) -> dict[str, str]:
+    """Last author to touch each finding's file, via `git log -1 --format=%an`.
+
+    Turns a flat findings report into something closer to what filing GitHub
+    issues per-owner needs: who to assign each file's fixes to. Best-effort --
+    a lesson_dir that isn't a git repo (or a `git log` failure on one file)
+    just means that location gets no author suffix, not a crash.
+    """
+    locations = sorted({f.location for f in findings if f.location})
+    blame: dict[str, str] = {}
+    for location in locations:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%an", "--", location],
+            cwd=lesson_dir,
+            capture_output=True,
+            text=True,
+        )
+        author = result.stdout.strip()
+        if result.returncode == 0 and author:
+            blame[location] = author
+    return blame
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Carpentries Workbench lesson checker")
     parser.add_argument("target", help="local lesson directory, or a git URL to clone and check")
@@ -53,6 +91,13 @@ def main(argv: list[str] | None = None) -> int:
         "--format", choices=("terminal", "markdown", "json"), default="terminal"
     )
     parser.add_argument("--output", help="write the report here instead of stdout")
+    parser.add_argument(
+        "--blame",
+        action="store_true",
+        help="annotate each file's findings with its last-touching author (git log -1), "
+        "useful for splitting a report into per-owner follow-up issues; requires "
+        "lesson_dir to be a git repo, silently skipped otherwise",
+    )
     parser.add_argument(
         "--html",
         action="store_true",
@@ -77,18 +122,25 @@ def main(argv: list[str] | None = None) -> int:
     try:
         findings = run_checks(lesson_dir, episode_filter=args.episode)
         title = f"Lesson Check Report — {args.target}"
+        blame = _blame_map(lesson_dir, findings) if args.blame else None
+        if args.blame and not blame:
+            print(
+                "--blame found no authors -- is lesson_dir a git repo with commit "
+                "history for these files?",
+                file=sys.stderr,
+            )
 
         if args.format == "terminal":
-            report_text = render_terminal(findings, title)
+            report_text = render_terminal(findings, title, blame=blame)
         elif args.format == "markdown":
-            report_text = render_markdown(findings, title)
+            report_text = render_markdown(findings, title, blame=blame)
         else:
             report_text = render_json(findings, title)
 
         _write_or_print(report_text, args.output)
 
         if args.html:
-            md_text = render_markdown(findings, title)
+            md_text = render_markdown(findings, title, blame=blame)
             out_path = Path(args.output).with_suffix(".html") if args.output else Path("report.html")
             try:
                 rendered = render_html_via_quarto(md_text, out_path)
@@ -111,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             if args.episode:
                 episode_files = [p for p in episode_files if p.name == args.episode]
+            glossary_text = _read_glossary(lesson_dir)
             for path in episode_files:
                 relative_location = str(path.relative_to(lesson_dir))
                 episode_findings = [f for f in findings if f.location == relative_location]
@@ -121,6 +174,7 @@ def main(argv: list[str] | None = None) -> int:
                     args.backend,
                     args.model,
                     args.embed_model,
+                    glossary_text,
                 )
                 print(review)
 

--- a/checker/report.py
+++ b/checker/report.py
@@ -34,7 +34,14 @@ def summarize(findings: list[Finding]) -> dict[str, int]:
     return counts
 
 
-def render_terminal(findings: list[Finding], title: str) -> str:
+def _blame_suffix(location: str, blame: dict[str, str] | None) -> str:
+    if not blame:
+        return ""
+    author = blame.get(location)
+    return f" (last touched by: {author})" if author else ""
+
+
+def render_terminal(findings: list[Finding], title: str, blame: dict[str, str] | None = None) -> str:
     lines = [f"\033[1m{title}\033[0m"]
     counts = summarize(findings)
     lines.append(
@@ -49,7 +56,7 @@ def render_terminal(findings: list[Finding], title: str) -> str:
         by_location.setdefault(f.location or "general", []).append(f)
 
     for location, items in by_location.items():
-        lines.append(f"\n\033[1m{location}\033[0m")
+        lines.append(f"\n\033[1m{location}\033[0m{_blame_suffix(location, blame)}")
         for f in items:
             icon = SEVERITY_ICON.get(f.severity, "")
             lines.append(f"  {icon} [{f.category}] {f.message}")
@@ -58,7 +65,9 @@ def render_terminal(findings: list[Finding], title: str) -> str:
     return "\n".join(lines)
 
 
-def render_markdown(findings: list[Finding], title: str) -> str:
+def render_markdown(
+    findings: list[Finding], title: str, blame: dict[str, str] | None = None
+) -> str:
     counts = summarize(findings)
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [
@@ -77,7 +86,7 @@ def render_markdown(findings: list[Finding], title: str) -> str:
         by_location.setdefault(f.location or "General", []).append(f)
 
     for location, items in by_location.items():
-        lines.append(f"## {location}")
+        lines.append(f"## {location}{_blame_suffix(location, blame)}")
         lines.append("")
         for f in items:
             icon = SEVERITY_ICON_PLAIN.get(f.severity, "")

--- a/tests/test_ai_review.py
+++ b/tests/test_ai_review.py
@@ -1,0 +1,27 @@
+"""Unit tests for the AI review prompt builder's glossary handling.
+
+Only `_build_prompt` is tested here -- it's pure string assembly. The rest
+of ai_review.py shells out to Ollama/Anthropic/Codex and isn't covered by
+this suite (see checker/ai_review.py's own docstring).
+"""
+
+from __future__ import annotations
+
+from checker.ai_review import _build_prompt
+
+
+def test_prompt_includes_glossary_gap_instruction():
+    prompt = _build_prompt("episode text", [], "style context")
+    assert "Glossary gaps" in prompt
+
+
+def test_prompt_with_glossary_text_includes_it_verbatim():
+    glossary = "Permissive license\n: Allows reuse with minimal restriction.\n"
+    prompt = _build_prompt("episode text", [], "style context", glossary_text=glossary)
+    assert glossary in prompt
+    assert "learners/reference.md" in prompt
+
+
+def test_prompt_without_glossary_text_says_so():
+    prompt = _build_prompt("episode text", [], "style context", glossary_text="")
+    assert "none found, or still the scaffold placeholder" in prompt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,64 @@
+"""Unit tests for the CLI's --blame support."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from checker.cli import _blame_map, _read_glossary
+from checker.report import Finding
+
+
+def _init_git_repo(path: Path):
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test Author"], cwd=path, check=True)
+
+
+def test_blame_map_reads_last_commit_author(tmp_path):
+    _init_git_repo(tmp_path)
+    (tmp_path / "episodes").mkdir()
+    ep = tmp_path / "episodes" / "ep.md"
+    ep.write_text("content\n")
+    subprocess.run(["git", "add", "episodes/ep.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add episode"], cwd=tmp_path, check=True)
+
+    findings = [Finding("error", "boilerplate", "msg", location="episodes/ep.md")]
+    blame = _blame_map(tmp_path, findings)
+    assert blame == {"episodes/ep.md": "Test Author"}
+
+
+def test_blame_map_not_a_git_repo_is_empty(tmp_path):
+    # No git init -- must not raise, just return nothing to annotate with.
+    (tmp_path / "episodes").mkdir()
+    (tmp_path / "episodes" / "ep.md").write_text("content\n")
+    findings = [Finding("error", "boilerplate", "msg", location="episodes/ep.md")]
+    assert _blame_map(tmp_path, findings) == {}
+
+
+def test_blame_map_ignores_findings_without_location(tmp_path):
+    _init_git_repo(tmp_path)
+    findings = [Finding("info", "config", "general note", location=None)]
+    assert _blame_map(tmp_path, findings) == {}
+
+
+# -- glossary reading for the --ai review's glossary-gap prompt -------------
+
+
+def test_read_glossary_missing_file_is_empty(tmp_path):
+    assert _read_glossary(tmp_path) == ""
+
+
+def test_read_glossary_placeholder_is_empty(tmp_path):
+    (tmp_path / "learners").mkdir()
+    (tmp_path / "learners" / "reference.md").write_text(
+        "---\ntitle: 'Reference'\n---\n\n## Glossary\n\nThis is a placeholder file. Please add content here.\n"
+    )
+    assert _read_glossary(tmp_path) == ""
+
+
+def test_read_glossary_real_content_is_returned(tmp_path):
+    (tmp_path / "learners").mkdir()
+    content = "---\ntitle: 'Reference'\n---\n\nPermissive license\n: Allows reuse.\n"
+    (tmp_path / "learners" / "reference.md").write_text(content)
+    assert _read_glossary(tmp_path) == content

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,31 @@
+"""Unit tests for report rendering, including --blame annotation."""
+
+from __future__ import annotations
+
+from checker.report import Finding, render_markdown, render_terminal
+
+
+def test_render_markdown_blame_annotates_heading():
+    findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
+    text = render_markdown(findings, "Report", blame={"episodes/ep.md": "Jose Niño"})
+    assert "## episodes/ep.md (last touched by: Jose Niño)" in text
+
+
+def test_render_markdown_no_blame_arg_is_unchanged():
+    findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
+    text = render_markdown(findings, "Report")
+    assert "## episodes/ep.md\n" in text
+    assert "last touched by" not in text
+
+
+def test_render_markdown_blame_missing_location_is_silent():
+    findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
+    text = render_markdown(findings, "Report", blame={"episodes/other.md": "Someone Else"})
+    assert "## episodes/ep.md\n" in text
+    assert "last touched by" not in text
+
+
+def test_render_terminal_blame_annotates_heading():
+    findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
+    text = render_terminal(findings, "Report", blame={"episodes/ep.md": "Karla Padilla"})
+    assert "(last touched by: Karla Padilla)" in text


### PR DESCRIPTION
## Summary

Follow-up to #14, which merged only its first commit (\`d0ba6cb\`, the boilerplate/placeholder detection work) and missed this branch's second commit. This PR brings in just that missing commit, live-verified via \`--backend claude\` against \`oss-license-workshop\` before #14 was merged (see PR #14's comment thread for the full transcript).

- **\`--blame\`**: annotates each file's findings section with its last-touching author (\`git log -1\`), so a report can be split into per-owner follow-up issues without a separate output mode.
- **AI glossary-gap suggestions**: the \`--ai\` narrative review now reads \`learners/reference.md\` (skipping it if still the scaffold placeholder) and adds a sixth review criterion asking for terms of art/jargon the episode uses that aren't already defined there, with a one-sentence draft definition each.

## Test plan
- [x] \`pixi run test\`: 66 passed (13 new: report blame rendering, cli blame-map and glossary-reading, ai_review prompt assembly)
- [x] Live-verified \`--ai --backend claude\` against \`episodes/why-license.md\`: correctly detected the empty glossary and suggested 7 real terms with lesson-scoped definitions