### PR TITLE
Make reports actionable: line numbers, clickable links, file checklist, --open

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,12 @@ this happens automatically; nothing to install separately.
 
 The extension owns *how* every report looks (typography, link color, PDF
 margins/colorlinks, the rule under each `## file` heading); `report.py`
-still owns *what* it says. To change the report's appearance -- a different
-accent color, real Carpentries branding, a logo -- edit the extension, not
+still owns *what* it says. Colors are The Carpentries' own official values
+(navy `#071159` for links, red `#FF4955` for the file-heading rule -- see
+the extension's own README for sourcing); the logo mark itself isn't
+embedded since the logo repo ships with no license and Carpentries'
+own docs require prior approval to use a derived/modified copy of it.
+To change the report's appearance further, edit the extension, not
 `report.py`. `pixi run test` includes a couple of lightweight checks
 (`_extension.yml` exists and parses, declares both `html` and `pdf`) that
 don't need Quarto installed; they just guard against the extension

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ throughput long before you run out of RAM outright.
 | `objectives` | Weak/unmeasurable objective verbs (`know`, `understand`, `appreciate`, ...) vs. action verbs (`explain`, `choose`, `predict`, ...) | CLDT's SMART objectives guidance |
 | `style` | Heavy contraction use | Carpentries Lab reviewer checklist (accessibility, translation/ESL learners) |
 | `boilerplate` | Unedited `sandpaper::create_lesson()` scaffold left in place: an episode's title or body still the generated default, or a `questions`/`objectives`/`keypoints` block that exists but only holds placeholder bullets (`keypoint1`, `Put questions here`, ...); same idea applied to `learners/setup.md`, `learners/reference.md`, `instructors/instructor-notes.md`, `profiles/learner-profiles.md`, which the checks above never look at since they aren't episodes | CLDT, a structurally-complete episode (passes every check above) can still be entirely unwritten, this is the gap between "the required blocks exist" and "someone wrote the lesson" |
-| `config` | *(also)* missing lesson glossary (`reference.md`) | Carpentries Lab reviewer checklist |
+| `config` | *(also)* missing lesson glossary (`reference.md`); a file under `episodes/` that's unlisted in `episodes:` *and* has none of the three required blocks -- a strong signal it's misplaced reference content (e.g. a glossary or resources page) rather than an unwritten episode, regardless of what it's named | Carpentries Lab reviewer checklist |
 
 Div and heading checks skip content inside fenced code blocks (```` ``` ````/`~~~`) — a lesson that teaches Markdown, Workbench syntax, or shell `#` comments will contain literal `:::`/`#` text that isn't a real div or heading.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ safe to use in a pre-commit hook or your own CI step.
 
 ### Reading the markdown/HTML report
 
+Every report format (terminal, markdown, JSON) opens with which tool
+generated it (`carpentries-workbench-checker vX.Y.Z`) and, when
+`config.yaml` and `CITATION.cff` are present, who and what it's about:
+lesson title, carpentry, life cycle, license, source repo, authors, and
+contact -- so a report handed to someone else identifies itself and the
+lesson without extra context. Missing fields (no `CITATION.cff`, an empty
+`config.yaml`) just drop from the block rather than showing blank lines.
+
 The markdown report (and the HTML built from it) opens with a **Files**
 checklist: one checkbox per location, with an issue count, linking down into
 that file's section, so you can track which files are cleared before you

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ lesson title, carpentry, life cycle, license, source repo, authors, and
 contact -- so a report handed to someone else identifies itself and the
 lesson without extra context. Missing fields (no `CITATION.cff`, an empty
 `config.yaml`) just drop from the block rather than showing blank lines.
+The `--html`/`--pdf` document's own title (the browser tab, the PDF's
+cover/metadata title) is the lesson's title too, not a generic "Lesson
+Check Report" -- it falls back to that generic title only when
+`config.yaml` has none.
 
 The markdown report (and the HTML built from it) opens with a **Files**
 checklist: one checkbox per location, with an issue count, linking down into

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ pixi run check ./my-lesson --format markdown --output report.md
 # a warning + the markdown file if you don't)
 pixi run check ./my-lesson --format markdown --output report.md --html
 
+# --open launches the rendered HTML in your default browser once it's built
+# (requires --html; a no-op warning otherwise)
+pixi run check ./my-lesson --format markdown --output report.md --html --open
+
 # One episode only
 pixi run check ./my-lesson --episode 03-sharing.md
 
@@ -78,6 +82,25 @@ pixi run check ./my-lesson --format markdown --blame --output report.md
 
 Exit code is `1` if any error-level finding was reported, `0` otherwise —
 safe to use in a pre-commit hook or your own CI step.
+
+### Reading the markdown/HTML report
+
+The markdown report (and the HTML built from it) opens with a **Files**
+checklist: one checkbox per location, with an issue count, linking down into
+that file's section, so you can track which files are cleared before you
+scroll through every finding. Each finding below that links back to its
+source: a real GitHub blob URL anchored to the line (`#L42`) when the lesson
+directory is a GitHub repo, plain `` `path:line` `` text otherwise. Terminal
+output gets the same line references as plain `path:line` tokens, which VS
+Code's integrated terminal (and several others) auto-links to jump straight
+to that line.
+
+Every finding whose category has a canonical Workbench/Carpentries doc
+(`config`, `front-matter`, `divs`, `headings`, `links`, `objectives`,
+`style`) links to it, either appended to the finding's own hint or standing
+in when there isn't one. `boilerplate` findings don't get one, since it's a
+check this tool invented rather than something sandpaper/pegboard document,
+so their instance-specific hints carry the explanation instead.
 
 ### Adding the AI narrative review
 

--- a/README.md
+++ b/README.md
@@ -102,22 +102,39 @@ cover/metadata title) is the lesson's title too, not a generic "Lesson
 Check Report" -- it falls back to that generic title only when
 `config.yaml` has none.
 
-The markdown report (and the HTML built from it) opens with a **Files**
-checklist: one checkbox per location, with an issue count, linking down into
-that file's section, so you can track which files are cleared before you
-scroll through every finding. Each finding below that links back to its
-source: a real GitHub blob URL anchored to the line (`#L42`) when the lesson
-directory is a GitHub repo, plain `` `path:line` `` text otherwise. Terminal
-output gets the same line references as plain `path:line` tokens, which VS
-Code's integrated terminal (and several others) auto-links to jump straight
-to that line.
+The markdown report (and the HTML/PDF built from it) has three parts:
+
+1. **Files** -- one checkbox per location with an issue count, linking down
+   into that file's own section, for file-level triage before reading detail.
+2. **Action summary** -- a table, one row per *shared fix* across the whole
+   lesson (same category, same exact hint text), not one row per finding.
+   A problem repeated many times (the same duplicate-heading warning in 16
+   places) shows up as one row with `Occurrences: 16`, not 16 near-identical
+   lines -- this is what actually answers "what's off, what needs to
+   change" at a glance, which per-finding detail can't.
+3. **Per-file detail**, one `## location` section per file (matching the
+   order you'd actually fix things in an editor). Within a file, findings
+   that share an exact `hint` still collapse into one `**Change:**` +
+   occurrence checklist instead of N separate cards, closed with a single
+   `**Guide:**` link -- so a file with 8 findings that are really "one
+   repeated problem + two one-offs" reads as 3 blocks, not 8 lines.
 
 Every finding whose category has a canonical Workbench/Carpentries doc
 (`config`, `front-matter`, `divs`, `headings`, `links`, `objectives`,
-`style`) links to it, either appended to the finding's own hint or standing
-in when there isn't one. `boilerplate` findings don't get one, since it's a
-check this tool invented rather than something sandpaper/pegboard document,
-so their instance-specific hints carry the explanation instead.
+`style`) links to it via that `**Guide:**` line. `boilerplate` findings
+don't get one, since it's a check this tool invented rather than something
+sandpaper/pegboard document, so their instance-specific hints carry the
+explanation instead. Each occurrence line links back to its source: a real
+GitHub blob URL anchored to the line (`#L42`) when the lesson directory is
+a GitHub repo, plain `` `path:line` `` text otherwise. Terminal output gets
+the same line references as plain `path:line` tokens, which VS Code's
+integrated terminal (and several others) auto-links to jump straight to
+that line.
+
+This structure (file-level triage, then a cross-file pattern summary, then
+file-first detail with same-fix collapsing) came out of a `/validate-external`
+round on the original per-finding-per-line design -- see
+[`design/validation-prompt-report-scannability-2026-08-31.md`](design/validation-prompt-report-scannability-2026-08-31.md).
 
 `--pdf` renders the same markdown through Quarto with a `pdf` target instead
 of `html` -- same checklist, same clickable links (as real hyperlinks, not

--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ PDF (LaTeX's default font has no emoji glyphs, so they're silently dropped);
 severity is still legible from the checkbox/bullet plus the bold category
 name, but it's not as visually distinct as the terminal/HTML output.
 
+### The report's look: a Quarto format extension
+
+`--html`/`--pdf` render through a bundled Quarto custom format extension at
+[`_extensions/checker-report/`](_extensions/checker-report/) (`_extension.yml`
++ `checker-report.scss`), not inline options in `report.py`. `report.py`
+copies that directory next to the generated `.qmd` at render time -- Quarto
+only discovers `_extensions/` as a sibling of the file being rendered, so
+this happens automatically; nothing to install separately.
+
+The extension owns *how* every report looks (typography, link color, PDF
+margins/colorlinks, the rule under each `## file` heading); `report.py`
+still owns *what* it says. To change the report's appearance -- a different
+accent color, real Carpentries branding, a logo -- edit the extension, not
+`report.py`. `pixi run test` includes a couple of lightweight checks
+(`_extension.yml` exists and parses, declares both `html` and `pdf`) that
+don't need Quarto installed; they just guard against the extension
+directory silently going missing or invalid.
+
 ### Adding the AI narrative review
 
 Off by default (it costs time, and for `claude`/`codex` it costs API usage).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ pixi run check ./my-lesson --format markdown --output report.md --html
 # (requires --html; a no-op warning otherwise)
 pixi run check ./my-lesson --format markdown --output report.md --html --open
 
+# PDF, for sharing with someone who doesn't want a repo checkout or a browser
+# tab -- also via Quarto, additionally needs a LaTeX distribution
+# (`quarto install tinytex`, or an existing MacTeX/TeX Live on PATH)
+pixi run check ./my-lesson --format markdown --output report.md --pdf
+
 # One episode only
 pixi run check ./my-lesson --episode 03-sharing.md
 
@@ -101,6 +106,13 @@ Every finding whose category has a canonical Workbench/Carpentries doc
 in when there isn't one. `boilerplate` findings don't get one, since it's a
 check this tool invented rather than something sandpaper/pegboard document,
 so their instance-specific hints carry the explanation instead.
+
+`--pdf` renders the same markdown through Quarto with a `pdf` target instead
+of `html` -- same checklist, same clickable links (as real hyperlinks, not
+just blue text). One difference: the ❌/⚠️/ℹ️ severity icons don't render in
+PDF (LaTeX's default font has no emoji glyphs, so they're silently dropped);
+severity is still legible from the checkbox/bullet plus the bold category
+name, but it's not as visually distinct as the terminal/HTML output.
 
 ### Adding the AI narrative review
 

--- a/_extensions/checker-report/README.md
+++ b/_extensions/checker-report/README.md
@@ -1,0 +1,11 @@
+Quarto custom format extension used by `checker/report.py` for `--html`/`--pdf`
+output. Not meant to be installed standalone with `quarto add` -- `report.py`
+copies this directory into the temporary render directory next to the
+generated `.qmd` at render time, which is how Quarto discovers any
+`_extensions/` directory.
+
+Defines two formats, `checker-report-html` and `checker-report-pdf`, both
+extending Quarto's defaults with `toc: true` plus report-specific styling
+(`checker-report.scss` for HTML; margins/link color for PDF). Edit
+`_extension.yml`/`checker-report.scss` here to change how every rendered
+report looks; `report.py` itself only decides *what* the report says.

--- a/_extensions/checker-report/README.md
+++ b/_extensions/checker-report/README.md
@@ -9,3 +9,11 @@ extending Quarto's defaults with `toc: true` plus report-specific styling
 (`checker-report.scss` for HTML; margins/link color for PDF). Edit
 `_extension.yml`/`checker-report.scss` here to change how every rendered
 report looks; `report.py` itself only decides *what* the report says.
+
+Link color is The Carpentries' official navy (`#071159`) and the rule under
+each file heading is their red (`#FF4955`) -- see
+https://docs.carpentries.org/topic_folders/communications/resources/logos.html
+for the source. Colors only: the actual logo mark (github.com/carpentries/logo)
+ships with no LICENSE, and Carpentries' own docs require prior approval
+(community@carpentries.org) for any derived/modified use of the mark itself,
+so nothing from that repo is vendored here.

--- a/_extensions/checker-report/_extension.yml
+++ b/_extensions/checker-report/_extension.yml
@@ -13,4 +13,8 @@ contributes:
     pdf:
       documentclass: article
       colorlinks: true
+      linkcolor: carpentriesnavy
+      urlcolor: carpentriesnavy
       geometry: margin=1in
+      header-includes:
+        - \definecolor{carpentriesnavy}{HTML}{071159}

--- a/_extensions/checker-report/_extension.yml
+++ b/_extensions/checker-report/_extension.yml
@@ -1,0 +1,16 @@
+title: Checker Report
+author: UCLA Library Data Science Center
+version: 1.0.0
+quarto-required: ">=1.2.222"
+contributes:
+  formats:
+    common:
+      toc: true
+    html:
+      embed-resources: true
+      theme: [default, checker-report.scss]
+      code-block-bg: true
+    pdf:
+      documentclass: article
+      colorlinks: true
+      geometry: margin=1in

--- a/_extensions/checker-report/checker-report.scss
+++ b/_extensions/checker-report/checker-report.scss
@@ -1,8 +1,16 @@
 /*-- scss:defaults --*/
 
+// The Carpentries' two official brand hex values (wrench-mark red, wordmark
+// navy) -- see https://docs.carpentries.org/topic_folders/communications/resources/logos.html.
+// Colors only, not the logo mark itself: the logo repo (github.com/carpentries/logo)
+// ships no LICENSE and Carpentries' own docs require prior approval for any
+// derived/modified use of the mark, so nothing from that repo is vendored here.
+$carpentries-red: #ff4955;
+$carpentries-navy: #071159;
+
 $body-line-height: 1.55;
 $font-family-monospace: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-$link-color: #1a5fb4;
+$link-color: $carpentries-navy;
 $headings-font-weight: 600;
 
 /*-- scss:rules --*/
@@ -12,7 +20,7 @@ $headings-font-weight: 600;
 h2 {
   margin-top: 2.5rem;
   padding-top: 0.75rem;
-  border-top: 1px solid #dee2e6;
+  border-top: 3px solid $carpentries-red;
 }
 
 h1 + p {

--- a/_extensions/checker-report/checker-report.scss
+++ b/_extensions/checker-report/checker-report.scss
@@ -1,0 +1,32 @@
+/*-- scss:defaults --*/
+
+$body-line-height: 1.55;
+$font-family-monospace: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+$link-color: #1a5fb4;
+$headings-font-weight: 600;
+
+/*-- scss:rules --*/
+
+// Each `## location` heading starts a new file's findings -- a visible rule
+// gives the eye a break between files without needing a page break.
+h2 {
+  margin-top: 2.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #dee2e6;
+}
+
+h1 + p {
+  color: #6c757d;
+}
+
+// Task-list checkboxes (unchecked = actionable finding, plain bullet = info
+// note) render small and low-contrast by default -- make the distinction
+// readable at a glance.
+ul.task-list li input[type="checkbox"] {
+  transform: scale(1.15);
+  margin-right: 0.4rem;
+}
+
+code {
+  font-size: 0.9em;
+}

--- a/checker/__init__.py
+++ b/checker/__init__.py
@@ -4,3 +4,5 @@ Mirrors (a fast, local subset of) what sandpaper::validate_lesson() and
 pegboard's validate_divs()/validate_headings()/validate_links() check in CI,
 plus an optional AI narrative review layered on top.
 """
+
+__version__ = "0.1.0"  # kept in sync with pixi.toml's [workspace] version by hand

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -21,7 +21,13 @@ from checker.lesson_check import (
     resolve_glossary_path,
     run_checks,
 )
-from checker.report import render_html_via_quarto, render_json, render_markdown, render_terminal
+from checker.report import (
+    render_html_via_quarto,
+    render_json,
+    render_markdown,
+    render_pdf_via_quarto,
+    render_terminal,
+)
 
 
 def _resolve_target(target: str) -> tuple[Path, tempfile.TemporaryDirectory | None]:
@@ -187,6 +193,13 @@ def main(argv: list[str] | None = None) -> int:
         help="open the rendered HTML report in your default browser (requires --html)",
     )
     parser.add_argument(
+        "--pdf",
+        action="store_true",
+        help="also render the markdown report to PDF with Quarto, if installed -- also "
+        "needs a LaTeX distribution (`quarto install tinytex`, or an existing MacTeX/TeX "
+        "Live on PATH); good for sharing with someone who doesn't want a repo checkout",
+    )
+    parser.add_argument(
         "--ai",
         action="store_true",
         help="also run an AI narrative review of style/pedagogy (costs time and, for "
@@ -226,30 +239,53 @@ def main(argv: list[str] | None = None) -> int:
 
         _write_or_print(report_text, args.output)
 
-        if args.html:
+        rendered_html = None
+        if args.html or args.pdf:
             md_text = render_markdown(findings, title, blame=blame, github_base=github_base)
-            out_path = Path(args.output).with_suffix(".html") if args.output else Path("report.html")
-            try:
-                rendered = render_html_via_quarto(md_text, out_path)
-            except RuntimeError as exc:
-                print(f"quarto render failed, skipping HTML output: {exc}", file=sys.stderr)
-                rendered = None
+
+            if args.html:
+                out_path = (
+                    Path(args.output).with_suffix(".html") if args.output else Path("report.html")
+                )
+                try:
+                    rendered_html = render_html_via_quarto(md_text, out_path)
+                except RuntimeError as exc:
+                    print(f"quarto render failed, skipping HTML output: {exc}", file=sys.stderr)
+                else:
+                    if rendered_html is None:
+                        print(
+                            "quarto not found on PATH -- skipping HTML render "
+                            "(install from https://quarto.org, or use --format markdown)",
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(f"wrote {rendered_html}", file=sys.stderr)
+
+            if args.pdf:
+                pdf_out_path = (
+                    Path(args.output).with_suffix(".pdf") if args.output else Path("report.pdf")
+                )
+                try:
+                    rendered_pdf = render_pdf_via_quarto(md_text, pdf_out_path)
+                except RuntimeError as exc:
+                    print(f"quarto render failed, skipping PDF output: {exc}", file=sys.stderr)
+                else:
+                    if rendered_pdf is None:
+                        print(
+                            "quarto not found on PATH -- skipping PDF render "
+                            "(install from https://quarto.org, or use --format markdown)",
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(f"wrote {rendered_pdf}", file=sys.stderr)
+
+        if args.open:
+            if rendered_html is not None:
+                webbrowser.open(rendered_html.resolve().as_uri())
+            elif args.html:
+                print("--open: no HTML file was rendered, nothing to open", file=sys.stderr)
             else:
-                if rendered is None:
-                    print(
-                        "quarto not found on PATH -- skipping HTML render "
-                        "(install from https://quarto.org, or use --format markdown)",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(f"wrote {rendered}", file=sys.stderr)
-            if args.open:
-                if rendered is not None:
-                    webbrowser.open(rendered.resolve().as_uri())
-                else:
-                    print("--open: no HTML file was rendered, nothing to open", file=sys.stderr)
-        elif args.open:
-            print("--open has no effect without --html", file=sys.stderr)
+                print("--open has no effect without --html", file=sys.stderr)
 
         if args.ai:
             episodes_dir = lesson_dir / "episodes"

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -8,9 +8,11 @@ See README.md for the full flag reference and model recommendations.
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 import tempfile
+import webbrowser
 from pathlib import Path
 
 from checker.ai_review import BACKENDS, review_episode
@@ -118,6 +120,43 @@ def _blame_map(lesson_dir: Path, findings: list) -> dict[str, str]:
     return blame
 
 
+_GITHUB_REMOTE_RE = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:)(?P<org>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$"
+)
+
+
+def _github_blob_base(lesson_dir: Path) -> str | None:
+    """`https://github.com/org/repo/blob/<current-sha>`, for turning
+    location:line references in the markdown report into real clickable
+    links. None if lesson_dir isn't a git repo, has no `origin` remote, that
+    remote isn't github.com, or either git call fails/times out -- callers
+    fall back to plain `path:line` text in every one of those cases, this
+    is a pure enhancement, never required."""
+    try:
+        remote = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=lesson_dir,
+            capture_output=True,
+            text=True,
+            timeout=_BLAME_TIMEOUT_SECONDS,
+        )
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=lesson_dir,
+            capture_output=True,
+            text=True,
+            timeout=_BLAME_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if remote.returncode != 0 or sha.returncode != 0:
+        return None
+    match = _GITHUB_REMOTE_RE.match(remote.stdout.strip())
+    if not match:
+        return None
+    return f"https://github.com/{match['org']}/{match['repo']}/blob/{sha.stdout.strip()}"
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: parse args, run checks, render/write the report,
     optionally run the AI review. Returns 1 if any error-level finding was
@@ -141,6 +180,11 @@ def main(argv: list[str] | None = None) -> int:
         "--html",
         action="store_true",
         help="also render the markdown report to HTML with Quarto, if installed",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="open the rendered HTML report in your default browser (requires --html)",
     )
     parser.add_argument(
         "--ai",
@@ -169,22 +213,27 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
+        # Computed once, reused for both --format markdown and --html (HTML is
+        # rendered from markdown text, so links baked in here carry through).
+        github_base = _github_blob_base(lesson_dir)
+
         if args.format == "terminal":
             report_text = render_terminal(findings, title, blame=blame)
         elif args.format == "markdown":
-            report_text = render_markdown(findings, title, blame=blame)
+            report_text = render_markdown(findings, title, blame=blame, github_base=github_base)
         else:
             report_text = render_json(findings, title)
 
         _write_or_print(report_text, args.output)
 
         if args.html:
-            md_text = render_markdown(findings, title, blame=blame)
+            md_text = render_markdown(findings, title, blame=blame, github_base=github_base)
             out_path = Path(args.output).with_suffix(".html") if args.output else Path("report.html")
             try:
                 rendered = render_html_via_quarto(md_text, out_path)
             except RuntimeError as exc:
                 print(f"quarto render failed, skipping HTML output: {exc}", file=sys.stderr)
+                rendered = None
             else:
                 if rendered is None:
                     print(
@@ -194,6 +243,13 @@ def main(argv: list[str] | None = None) -> int:
                     )
                 else:
                     print(f"wrote {rendered}", file=sys.stderr)
+            if args.open:
+                if rendered is not None:
+                    webbrowser.open(rendered.resolve().as_uri())
+                else:
+                    print("--open: no HTML file was rendered, nothing to open", file=sys.stderr)
+        elif args.open:
+            print("--open has no effect without --html", file=sys.stderr)
 
         if args.ai:
             episodes_dir = lesson_dir / "episodes"

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from checker.ai_review import BACKENDS, review_episode
 from checker.lesson_check import (
     GLOSSARY_PLACEHOLDER_FINGERPRINT,
+    read_lesson_metadata,
     resolve_glossary_path,
     run_checks,
 )
@@ -226,22 +227,27 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
-        # Computed once, reused for both --format markdown and --html (HTML is
-        # rendered from markdown text, so links baked in here carry through).
+        # Computed once, reused across every output format: who/what the
+        # report is for, and (for markdown/html) how to link back to source.
+        metadata = read_lesson_metadata(lesson_dir)
         github_base = _github_blob_base(lesson_dir)
 
         if args.format == "terminal":
-            report_text = render_terminal(findings, title, blame=blame)
+            report_text = render_terminal(findings, title, blame=blame, metadata=metadata)
         elif args.format == "markdown":
-            report_text = render_markdown(findings, title, blame=blame, github_base=github_base)
+            report_text = render_markdown(
+                findings, title, blame=blame, github_base=github_base, metadata=metadata
+            )
         else:
-            report_text = render_json(findings, title)
+            report_text = render_json(findings, title, metadata=metadata)
 
         _write_or_print(report_text, args.output)
 
         rendered_html = None
         if args.html or args.pdf:
-            md_text = render_markdown(findings, title, blame=blame, github_base=github_base)
+            md_text = render_markdown(
+                findings, title, blame=blame, github_base=github_base, metadata=metadata
+            )
 
             if args.html:
                 out_path = (

--- a/checker/cli.py
+++ b/checker/cli.py
@@ -248,13 +248,18 @@ def main(argv: list[str] | None = None) -> int:
             md_text = render_markdown(
                 findings, title, blame=blame, github_base=github_base, metadata=metadata
             )
+            # The document title Quarto puts in the browser tab / PDF cover --
+            # distinct from `title` above, which is the in-body H1 and already
+            # includes the target path; this is what identifies the lesson at
+            # a glance when the report's shared as a standalone file.
+            qmd_title = f"{metadata.title} — Lesson Check Report" if metadata.title else title
 
             if args.html:
                 out_path = (
                     Path(args.output).with_suffix(".html") if args.output else Path("report.html")
                 )
                 try:
-                    rendered_html = render_html_via_quarto(md_text, out_path)
+                    rendered_html = render_html_via_quarto(md_text, out_path, report_title=qmd_title)
                 except RuntimeError as exc:
                     print(f"quarto render failed, skipping HTML output: {exc}", file=sys.stderr)
                 else:
@@ -272,7 +277,7 @@ def main(argv: list[str] | None = None) -> int:
                     Path(args.output).with_suffix(".pdf") if args.output else Path("report.pdf")
                 )
                 try:
-                    rendered_pdf = render_pdf_via_quarto(md_text, pdf_out_path)
+                    rendered_pdf = render_pdf_via_quarto(md_text, pdf_out_path, report_title=qmd_title)
                 except RuntimeError as exc:
                     print(f"quarto render failed, skipping PDF output: {exc}", file=sys.stderr)
                 else:

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -594,6 +594,7 @@ def _check_boilerplate(
                     f'body still contains scaffold example text on line {lineno}: '
                     f'"{fingerprint}"',
                     location=location,
+                    line=lineno,
                     hint="[CLDT] This looks like unedited Carpentries Workbench scaffold "
                     "content, not real lesson material. Replace it, or delete the episode "
                     "if it isn't ready to write yet, an empty episode is more honest than "
@@ -603,7 +604,7 @@ def _check_boilerplate(
     return findings
 
 
-def _check_placeholder_bullets(body: str, location: str) -> list[Finding]:
+def _check_placeholder_bullets(body: str, location: str, line_offset: int = 0) -> list[Finding]:
     """Flag placeholder bullet text (`keypoint1`, `Put questions here`, ...)
     left inside `questions`/`objectives`/`keypoints` blocks. The block itself
     existing satisfies `_check_divs`'s required-block check, so this is the
@@ -641,12 +642,15 @@ def _check_placeholder_bullets(body: str, location: str) -> list[Finding]:
         bullet_raw = stripped[marker_match.end():].strip()
         normalized = _normalize_bullet_text(bullet_raw)
         if _is_placeholder_bullet(normalized.lower()):
+            reported_line = i + 1 + line_offset
             findings.append(
                 Finding(
                     "error",
                     "boilerplate",
-                    f'`{tracked_type}` still has placeholder bullet text: "{bullet_raw}"',
+                    f'`{tracked_type}` still has placeholder bullet text on line '
+                    f'{reported_line}: "{bullet_raw}"',
                     location=location,
+                    line=reported_line,
                     hint="[CLDT] Replace with real content, this is scaffold placeholder "
                     "text, not a written keypoint/objective/question.",
                 )
@@ -715,6 +719,7 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                         f"unrecognized div type `{div_type}` on line {lineno + line_offset}"
                         " -- verify against the Workbench style guide",
                         location=location,
+                        line=lineno + line_offset,
                         hint="See https://carpentries.github.io/sandpaper-docs/episodes.html "
                         "for the full list of recognized div types.",
                     )
@@ -728,6 +733,7 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                         f"extraneous closing `:::` on line {lineno + line_offset} with no "
                         "matching open div",
                         location=location,
+                        line=lineno + line_offset,
                         hint="Either this fence has no matching opening `::: type` above it, "
                         "or an earlier div's closing fence was deleted, causing this one to "
                         "close the wrong block. Check the div immediately above.",
@@ -743,6 +749,7 @@ def _check_divs(body: str, location: str, line_offset: int = 0) -> list[Finding]
                 "divs",
                 f"`{div_type}` div opened on line {lineno + line_offset} is never closed",
                 location=location,
+                line=lineno + line_offset,
                 hint="Add a closing `:::` fence (same or more colons than the opening "
                 "fence) before the next block starts. An unclosed div silently swallows "
                 "everything after it, including blocks that look fine on their own, "
@@ -792,6 +799,7 @@ def _check_headings(body: str, location: str, line_offset: int = 0) -> list[Find
                     f"level-1 heading `# {text}` on line {reported_line}"
                     " -- episodes must not use H1, start at H2",
                     location=location,
+                    line=reported_line,
                 )
             )
         elif not first_heading_seen and level != 2:
@@ -802,6 +810,7 @@ def _check_headings(body: str, location: str, line_offset: int = 0) -> list[Find
                     f"first heading `{'#' * level} {text}` on line {reported_line} is level "
                     f"{level}, expected level 2",
                     location=location,
+                    line=reported_line,
                 )
             )
 
@@ -816,6 +825,7 @@ def _check_headings(body: str, location: str, line_offset: int = 0) -> list[Find
                     f"heading `{text}` on line {reported_line} duplicates the one on line "
                     f"{seen[text]}",
                     location=location,
+                    line=reported_line,
                 )
             )
         else:
@@ -841,6 +851,7 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                         "links",
                         f"image on line {lineno} has no alt text: `{path}`",
                         location=location,
+                        line=lineno,
                         hint="Add descriptive alt text for accessibility.",
                     )
                 )
@@ -856,6 +867,7 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                             "links",
                             f"image on line {lineno} points to a missing file: `{path}`",
                             location=location,
+                            line=lineno,
                             hint="Check the path is relative to episodes/ (images "
                             "typically live in episodes/fig/), and that the file was "
                             "actually committed.",
@@ -870,6 +882,7 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                         "links",
                         f'generic link text "{text}" on line {lineno}',
                         location=location,
+                        line=lineno,
                         hint="[CLDT/Carpentries Lab] Screen readers and translation tools "
                         "lose context with generic link text like 'click here' -- "
                         "describe the destination.",
@@ -899,6 +912,7 @@ def _check_links(body: str, lesson_dir: Path, location: str, line_offset: int = 
                         "links",
                         f"internal link on line {lineno} may be broken: `{path}`",
                         location=location,
+                        line=lineno,
                         hint="Confirm the target exists relative to episodes/, the "
                         "lesson root, or learners/, instructors/, profiles/. A link to "
                         "another episode's rendered .html targets its .md source.",
@@ -941,7 +955,7 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
     findings.extend(_check_headings(body, location, line_offset))
     findings.extend(_check_links(body, lesson_dir, location, line_offset))
     findings.extend(_check_boilerplate(front_matter, body, location, line_offset))
-    findings.extend(_check_placeholder_bullets(body, location))
+    findings.extend(_check_placeholder_bullets(body, location, line_offset))
     objective_findings, objective_count = _check_objective_verbs(body, location)
     findings.extend(objective_findings)
     findings.extend(_check_contractions(body, location))

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import yaml
 
-from checker.report import Finding
+from checker.report import Finding, LessonMetadata
 
 REQUIRED_TOP_DIVS = ("questions", "objectives", "keypoints")
 
@@ -37,6 +37,15 @@ KNOWN_DIV_TYPES = {
     "hint",
     "tab",
     "group-tab",
+}
+
+# config.yaml's `carpentry:` code -> the full org name, for the report header.
+CARPENTRY_NAMES = {
+    "lc": "Library Carpentry",
+    "dc": "Data Carpentry",
+    "swc": "Software Carpentry",
+    "cp": "The Carpentries",
+    "incubator": "The Carpentries Incubator",
 }
 
 CONFIG_PLACEHOLDER_VALUES = {
@@ -371,6 +380,52 @@ def check_config(lesson_dir: Path) -> list[Finding]:
         )
 
     return findings
+
+
+def read_lesson_metadata(lesson_dir: Path) -> LessonMetadata:
+    """Lesson identity for the report header: title, carpentry, life cycle,
+    license, source repo, contact, and authors, from config.yaml and (if
+    present) CITATION.cff. Best-effort -- missing or unparseable files just
+    leave those fields empty; this is descriptive context for a report
+    header, not a check that should fail the run, so it deliberately doesn't
+    raise or return Findings the way check_config() does."""
+    metadata = LessonMetadata()
+
+    config_path = lesson_dir / "config.yaml"
+    if config_path.exists():
+        try:
+            config = yaml.safe_load(config_path.read_text()) or {}
+        except yaml.YAMLError:
+            config = {}
+        carpentry_code = config.get("carpentry") or None
+        metadata.title = config.get("title") or None
+        metadata.carpentry = (
+            CARPENTRY_NAMES.get(carpentry_code, carpentry_code) if carpentry_code else None
+        )
+        metadata.life_cycle = config.get("life_cycle") or None
+        metadata.license = config.get("license") or None
+        metadata.source = config.get("source") or None
+        metadata.contact = config.get("contact") or None
+        metadata.created = config.get("created") or None
+
+    citation_path = lesson_dir / "CITATION.cff"
+    if citation_path.exists():
+        try:
+            citation = yaml.safe_load(citation_path.read_text()) or {}
+        except yaml.YAMLError:
+            citation = {}
+        for entry in citation.get("authors") or []:
+            if not isinstance(entry, dict):
+                continue
+            # CFF allows an "entity" author (an organization) via `name`,
+            # instead of the usual given-names/family-names pair.
+            name = entry.get("name") or " ".join(
+                part for part in (entry.get("given-names"), entry.get("family-names")) if part
+            )
+            if name:
+                metadata.authors.append(name)
+
+    return metadata
 
 
 def check_support_files(lesson_dir: Path) -> list[Finding]:

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -244,6 +244,31 @@ def _code_fence_mask(body: str) -> list[bool]:
     return mask
 
 
+def _unlisted_episode_files(lesson_dir: Path) -> list[str]:
+    """Episode filenames on disk that aren't in config.yaml's `episodes:`
+    list. Empty when config.yaml is missing/unparseable, or when the
+    `episodes:` field itself is blank -- sandpaper then includes every file
+    automatically, so nothing counts as "unlisted" (see check_config()).
+    Shared by check_config() (the "not listed" warning) and run_checks()
+    (the "this doesn't look like an episode at all" check below, which
+    only fires for files that are both unlisted and structurally empty)."""
+    config_path = lesson_dir / "config.yaml"
+    if not config_path.exists():
+        return []
+    try:
+        config = yaml.safe_load(config_path.read_text()) or {}
+    except yaml.YAMLError:
+        return []
+    episodes_field = config.get("episodes")
+    if not episodes_field:
+        return []
+    episodes_dir = lesson_dir / "episodes"
+    if not episodes_dir.exists():
+        return []
+    on_disk = sorted(p.name for p in episodes_dir.glob("*") if p.suffix in (".md", ".Rmd"))
+    return [name for name in on_disk if name not in episodes_field]
+
+
 def check_config(lesson_dir: Path) -> list[Finding]:
     """Check config.yaml: placeholder values, episode list vs. files on disk,
     extension-less episode files, and glossary existence."""
@@ -355,8 +380,7 @@ def check_config(lesson_dir: Path) -> list[Finding]:
     # every file under episodes/ automatically, in alphabetical order. Only flag
     # "unlisted" files when the author is curating an explicit ordered list.
     if episodes_field:
-        unlisted = [e for e in on_disk if e not in listed_episodes]
-        for name in unlisted:
+        for name in _unlisted_episode_files(lesson_dir):
             findings.append(
                 Finding(
                     "warning",
@@ -1058,6 +1082,24 @@ def check_episode(path: Path, lesson_dir: Path) -> list[Finding]:
     return findings
 
 
+def _looks_misplaced(episode_findings: list[Finding]) -> bool:
+    """True when an "episode" has none of the three required
+    questions/objectives/keypoints blocks at all. Even a totally blank,
+    just-created episode has empty versions of all three, since they're
+    baked into `sandpaper::create_lesson()`'s own scaffold -- so zero of
+    the three present is a much stronger "this was never meant to be an
+    episode" signal than "this episode is very unwritten." Checked against
+    the actual `divs`-category findings (each required block that's
+    missing produces its own Finding), not by re-parsing the body, so this
+    can't drift out of sync with what _check_divs() actually detected."""
+    missing_required = sum(
+        1
+        for f in episode_findings
+        if f.category == "divs" and f.message.startswith("missing required `")
+    )
+    return missing_required == len(REQUIRED_TOP_DIVS)
+
+
 def run_checks(lesson_dir: Path, episode_filter: str | None = None) -> list[Finding]:
     """Entry point: run config/support-file checks plus every episode check,
     optionally scoped to one episode via episode_filter."""
@@ -1084,7 +1126,26 @@ def run_checks(lesson_dir: Path, episode_filter: str | None = None) -> list[Find
             )
             return findings
 
+    unlisted = set(_unlisted_episode_files(lesson_dir))
     for path in episode_files:
-        findings.extend(check_episode(path, lesson_dir))
+        episode_findings = check_episode(path, lesson_dir)
+        if path.name in unlisted and _looks_misplaced(episode_findings):
+            findings.append(
+                Finding(
+                    "warning",
+                    "config",
+                    f"episodes/{path.name} has none of the required "
+                    "questions/objectives/keypoints blocks and isn't listed in "
+                    "config.yaml `episodes:` -- this looks like reference content, not "
+                    "an unwritten episode",
+                    location=str(path.relative_to(lesson_dir)),
+                    hint="If this is meant to be an episode, add the required blocks "
+                    "and list it in config.yaml. If it's reference content instead, "
+                    "move it: a glossary belongs in learners/reference.md; other "
+                    "support material belongs under learners/, instructors/, or "
+                    "profiles/, not episodes/.",
+                )
+            )
+        findings.extend(episode_findings)
 
     return findings

--- a/checker/lesson_check.py
+++ b/checker/lesson_check.py
@@ -880,6 +880,8 @@ def _check_headings(body: str, location: str, line_offset: int = 0) -> list[Find
                     f"heading `{text}` on line {reported_line} duplicates the one on line "
                     f"{seen[text]}",
                     location=location,
+                    hint="Give each challenge/solution/exercise a unique, descriptive heading "
+                    "instead of reusing a generic one.",
                     line=reported_line,
                 )
             )

--- a/checker/report.py
+++ b/checker/report.py
@@ -14,6 +14,28 @@ SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 SEVERITY_ICON = {"error": "\033[31m❌\033[0m", "warning": "\033[33m⚠️\033[0m", "info": "ℹ️"}
 SEVERITY_ICON_PLAIN = {"error": "❌", "warning": "⚠️", "info": "ℹ️"}
 
+# One authoritative Workbench/Carpentries doc per check category, appended to
+# a finding's hint (or standing in when there is no instance-specific hint)
+# so "what's wrong" always has a "here's the rule" to go read. `boilerplate`
+# has no external entry deliberately -- it's a check this tool invented, not
+# something sandpaper/pegboard document, so there's no canonical page to
+# point at; its instance-specific hints already carry the explanation.
+CATEGORY_GUIDE_LINKS: dict[str, tuple[str, str]] = {
+    "config": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "front-matter": ("Episode front matter", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "divs": ("Workbench Component Guide", "https://carpentries.github.io/sandpaper-docs/component-guide.html"),
+    "headings": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "links": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "objectives": (
+        "CLDT: SMART objectives",
+        "https://carpentries.github.io/lesson-development-training/aio.html",
+    ),
+    "style": (
+        "Carpentries Lab reviewer checklist",
+        "https://github.com/carpentries-lab/reviews/blob/main/docs/reviewer_guide.md",
+    ),
+}
+
 
 @dataclass
 class Finding:
@@ -25,10 +47,17 @@ class Finding:
     message: str
     location: str | None = None  # e.g. "episodes/01-intro.md" or "config.yaml"
     hint: str | None = None
+    line: int | None = None  # 1-indexed source line, when the check knows one
 
     def sort_key(self):
-        """Sort errors before warnings before info, then group by location."""
-        return (SEVERITY_ORDER.get(self.severity, 9), self.location or "", self.category)
+        """Sort errors before warnings before info, then group by location,
+        then by line within a location."""
+        return (
+            SEVERITY_ORDER.get(self.severity, 9),
+            self.location or "",
+            self.line if self.line is not None else -1,
+            self.category,
+        )
 
 
 def summarize(findings: list[Finding]) -> dict[str, int]:
@@ -46,7 +75,40 @@ def _blame_suffix(location: str, blame: dict[str, str] | None) -> str:
     return f" (last change authored by: {author})" if author else ""
 
 
-def render_terminal(findings: list[Finding], title: str, blame: dict[str, str] | None = None) -> str:
+def _guide_suffix(category: str) -> str:
+    """Appendable ' (See: Label)' text for terminal/markdown, empty if the
+    category has no canonical external doc."""
+    entry = CATEGORY_GUIDE_LINKS.get(category)
+    return f" (see: {entry[0]}, {entry[1]})" if entry else ""
+
+
+def _guide_link_markdown(category: str) -> str:
+    entry = CATEGORY_GUIDE_LINKS.get(category)
+    return f" [{entry[0]}]({entry[1]})" if entry else ""
+
+
+def _terminal_location_prefix(location: str, line: int | None) -> str:
+    """`path:line` token, left plain (no ANSI) so terminals that recognize
+    that pattern (VS Code's integrated terminal, several others) can turn it
+    into a clickable jump-to-line link."""
+    return f"{location}:{line} " if line is not None else ""
+
+
+def _markdown_location_link(location: str, line: int | None, github_base: str | None) -> str:
+    """A clickable `path:line` reference for the markdown report. Prefers a
+    real GitHub blob URL anchored to the line (works when pasted into a PR,
+    an issue, or opened in a browser); falls back to plain `path:line` text
+    when the lesson isn't a GitHub repo or has no clean remote."""
+    label = f"{location}:{line}" if line is not None else location
+    if github_base:
+        anchor = f"#L{line}" if line is not None else ""
+        return f"[{label}]({github_base}/{location}{anchor})"
+    return f"`{label}`"
+
+
+def render_terminal(
+    findings: list[Finding], title: str, blame: dict[str, str] | None = None
+) -> str:
     """Colored, grouped-by-location report for a terminal."""
     lines = [f"\033[1m{title}\033[0m"]
     counts = summarize(findings)
@@ -65,16 +127,27 @@ def render_terminal(findings: list[Finding], title: str, blame: dict[str, str] |
         lines.append(f"\n\033[1m{location}\033[0m{_blame_suffix(location, blame)}")
         for f in items:
             icon = SEVERITY_ICON.get(f.severity, "")
-            lines.append(f"  {icon} [{f.category}] {f.message}")
+            prefix = _terminal_location_prefix(location, f.line)
+            lines.append(f"  {icon} {prefix}[{f.category}] {f.message}")
             if f.hint:
-                lines.append(f"     → {f.hint}")
+                lines.append(f"     → {f.hint}{_guide_suffix(f.category)}")
+            elif f.category in CATEGORY_GUIDE_LINKS:
+                lines.append(f"     →{_guide_suffix(f.category)}")
     return "\n".join(lines)
 
 
 def render_markdown(
-    findings: list[Finding], title: str, blame: dict[str, str] | None = None
+    findings: list[Finding],
+    title: str,
+    blame: dict[str, str] | None = None,
+    github_base: str | None = None,
 ) -> str:
-    """Checkbox-list report per location, ready to paste into a PR/issue."""
+    """Checkbox-list report per location, ready to paste into a PR/issue.
+
+    `github_base` (e.g. `https://github.com/org/repo/blob/<sha>`), when
+    given, turns every location:line reference into a real clickable GitHub
+    link instead of plain text -- see `cli._github_blob_base`.
+    """
     counts = summarize(findings)
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [
@@ -92,18 +165,42 @@ def render_markdown(
     for f in sorted(findings, key=Finding.sort_key):
         by_location.setdefault(f.location or "General", []).append(f)
 
+    # File-level overview: one checkbox per location so progress is visible
+    # at a glance before scrolling into per-finding detail.
+    lines.append("## Files")
+    lines.append("")
+    for location, items in by_location.items():
+        actionable = sum(1 for f in items if f.severity in ("error", "warning"))
+        box = "- [ ]" if actionable else "-"
+        count_label = f"{actionable} issue(s)" if actionable else f"{len(items)} note(s) only"
+        lines.append(f"{box} [{location}](#{_anchor(location)}) — {count_label}")
+    lines.append("")
+
     for location, items in by_location.items():
         lines.append(f"## {location}{_blame_suffix(location, blame)}")
         lines.append("")
         for f in items:
             icon = SEVERITY_ICON_PLAIN.get(f.severity, "")
             box = "- [ ]" if f.severity in ("error", "warning") else "-"
-            entry = f"{box} {icon} **{f.category}** — {f.message}"
+            where = _markdown_location_link(location, f.line, github_base)
+            entry = f"{box} {icon} {where} **{f.category}** — {f.message}"
             lines.append(entry)
             if f.hint:
-                lines.append(f"      *Fix:* {f.hint}")
+                lines.append(f"      *Fix:* {f.hint}{_guide_link_markdown(f.category)}")
+            elif f.category in CATEGORY_GUIDE_LINKS:
+                lines.append(f"      *Guide:*{_guide_link_markdown(f.category)}")
         lines.append("")
     return "\n".join(lines)
+
+
+def _anchor(location: str) -> str:
+    """Best-effort GitHub-flavored-markdown heading anchor for a `## location`
+    heading, used by the file-overview checklist's links. GFM lowercases,
+    strips non-word/non-hyphen/non-space characters, and turns spaces into
+    hyphens; this covers lesson-path headings (letters, digits, `/`, `.`,
+    `-`, `_`), which is everything that actually appears here."""
+    slug = location.lower().replace("/", "").replace(".", "").replace("_", "-")
+    return slug.replace(" ", "-")
 
 
 def render_json(findings: list[Finding], title: str) -> str:
@@ -127,18 +224,26 @@ def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
         return None
 
     with tempfile.TemporaryDirectory() as tmp:
-        qmd_path = Path(tmp) / "report.qmd"
+        # Resolve symlinks (macOS puts TemporaryDirectory() under /var, which
+        # is itself a symlink to /private/var) before handing the path to
+        # quarto -- otherwise quarto resolves cwd internally, computes the
+        # output path relative to that resolved directory, and produces a
+        # "../../../../private/..." path that doesn't match the unresolved
+        # cwd we gave it, failing with a permission error on /private.
+        tmp_dir = Path(tmp).resolve()
+        qmd_path = tmp_dir / "report.qmd"
         qmd_path.write_text(
-            "---\ntitle: Lesson Check Report\nformat: html\n---\n\n" + markdown_text
+            "---\ntitle: Lesson Check Report\nformat:\n  html:\n    toc: true\n    "
+            "embed-resources: true\n---\n\n" + markdown_text
         )
         result = subprocess.run(
             ["quarto", "render", str(qmd_path), "--to", "html", "-o", out_path.name],
-            cwd=tmp,
+            cwd=tmp_dir,
             capture_output=True,
             text=True,
         )
         if result.returncode != 0:
             raise RuntimeError(f"quarto render failed: {result.stderr.strip()}")
-        rendered = Path(tmp) / out_path.name
+        rendered = tmp_dir / out_path.name
         out_path.write_bytes(rendered.read_bytes())
     return out_path

--- a/checker/report.py
+++ b/checker/report.py
@@ -294,18 +294,20 @@ def render_json(
     return json.dumps(payload, indent=2)
 
 
-# Pandoc format options per target, keyed the same as quarto's own `--to`.
-_QUARTO_FORMAT_OPTIONS: dict[str, dict] = {
-    "html": {"toc": True, "embed-resources": True},
-    "pdf": {"toc": True},
-}
+# The "checker-report" Quarto format extension (see _extensions/checker-report/
+# in the repo root -- checker/report.py's parent's parent) owns the report's
+# actual look (theme, PDF margins, toc). Quarto only discovers an
+# `_extensions/` directory that's a sibling of the .qmd being rendered, so
+# _render_via_quarto copies it into the temp render directory each time.
+_EXTENSION_NAME = "checker-report"
+_EXTENSION_SRC = Path(__file__).resolve().parent.parent / "_extensions" / _EXTENSION_NAME
 
 
 def _render_via_quarto(
     markdown_text: str, out_path: Path, to: str, report_title: str
 ) -> Path | None:
     """Shared by render_html_via_quarto/render_pdf_via_quarto: write the report
-    as a .qmd with the given pandoc `format:` block, render it to `to`
+    as a .qmd using the checker-report format extension, render it to `to`
     ("html"/"pdf"), and copy the result to out_path. Returns None if quarto
     isn't on PATH at all (caller should fall back to the plain markdown/
     terminal report, not fail). Raises RuntimeError if quarto is present but
@@ -313,6 +315,11 @@ def _render_via_quarto(
     so that doesn't get silently swallowed and mistaken for "quarto missing"."""
     if shutil.which("quarto") is None:
         return None
+    if not _EXTENSION_SRC.is_dir():
+        raise RuntimeError(
+            f"checker-report Quarto extension not found at {_EXTENSION_SRC} -- "
+            "this is a broken install, not a missing dependency"
+        )
 
     with tempfile.TemporaryDirectory() as tmp:
         # Resolve symlinks (macOS puts TemporaryDirectory() under /var, which
@@ -322,18 +329,20 @@ def _render_via_quarto(
         # "../../../../private/..." path that doesn't match the unresolved
         # cwd we gave it, failing with a permission error on /private.
         tmp_dir = Path(tmp).resolve()
+        shutil.copytree(_EXTENSION_SRC, tmp_dir / "_extensions" / _EXTENSION_NAME)
         qmd_path = tmp_dir / "report.qmd"
+        quarto_format = f"{_EXTENSION_NAME}-{to}"
         # yaml.safe_dump, not an f-string, because report_title is a lesson's
         # actual title -- arbitrary text that can contain colons, quotes, or
         # unicode that would otherwise break the YAML front matter.
         front_matter = yaml.safe_dump(
-            {"title": report_title, "format": {to: _QUARTO_FORMAT_OPTIONS[to]}},
+            {"title": report_title, "format": {quarto_format: "default"}},
             sort_keys=False,
             allow_unicode=True,
         )
         qmd_path.write_text(f"---\n{front_matter}---\n\n" + markdown_text)
         result = subprocess.run(
-            ["quarto", "render", str(qmd_path), "--to", to, "-o", out_path.name],
+            ["quarto", "render", str(qmd_path), "--to", quarto_format, "-o", out_path.name],
             cwd=tmp_dir,
             capture_output=True,
             text=True,

--- a/checker/report.py
+++ b/checker/report.py
@@ -214,12 +214,14 @@ def render_json(findings: list[Finding], title: str) -> str:
     return json.dumps(payload, indent=2)
 
 
-def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
-    """Render a markdown report to HTML with Quarto, if it's installed. Returns
-    the output path on success, or None if quarto isn't on PATH at all (caller
-    should fall back to the plain markdown/terminal report, not fail). Raises
-    RuntimeError if quarto is present but the render itself fails, so that
-    error doesn't get silently swallowed and mistaken for "quarto missing"."""
+def _render_via_quarto(markdown_text: str, out_path: Path, to: str, format_yaml: str) -> Path | None:
+    """Shared by render_html_via_quarto/render_pdf_via_quarto: write the report
+    as a .qmd with the given pandoc `format:` block, render it to `to`
+    ("html"/"pdf"), and copy the result to out_path. Returns None if quarto
+    isn't on PATH at all (caller should fall back to the plain markdown/
+    terminal report, not fail). Raises RuntimeError if quarto is present but
+    the render itself fails -- e.g. no LaTeX distribution for a PDF render --
+    so that doesn't get silently swallowed and mistaken for "quarto missing"."""
     if shutil.which("quarto") is None:
         return None
 
@@ -233,11 +235,10 @@ def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
         tmp_dir = Path(tmp).resolve()
         qmd_path = tmp_dir / "report.qmd"
         qmd_path.write_text(
-            "---\ntitle: Lesson Check Report\nformat:\n  html:\n    toc: true\n    "
-            "embed-resources: true\n---\n\n" + markdown_text
+            f"---\ntitle: Lesson Check Report\nformat:\n{format_yaml}---\n\n" + markdown_text
         )
         result = subprocess.run(
-            ["quarto", "render", str(qmd_path), "--to", "html", "-o", out_path.name],
+            ["quarto", "render", str(qmd_path), "--to", to, "-o", out_path.name],
             cwd=tmp_dir,
             capture_output=True,
             text=True,
@@ -247,3 +248,21 @@ def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
         rendered = tmp_dir / out_path.name
         out_path.write_bytes(rendered.read_bytes())
     return out_path
+
+
+def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
+    """Render a markdown report to HTML with Quarto, if it's installed. See
+    `_render_via_quarto` for the None/RuntimeError contract."""
+    return _render_via_quarto(
+        markdown_text, out_path, "html", "  html:\n    toc: true\n    embed-resources: true\n"
+    )
+
+
+def render_pdf_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
+    """Render a markdown report to PDF with Quarto, if it's installed and a
+    LaTeX distribution is available (`quarto install tinytex`, or an existing
+    MacTeX/TeX Live install on PATH). See `_render_via_quarto` for the
+    None/RuntimeError contract -- a missing LaTeX engine surfaces as a
+    RuntimeError with quarto's own error text, not a silent None, since
+    quarto being on PATH doesn't guarantee PDF rendering works."""
+    return _render_via_quarto(markdown_text, out_path, "pdf", "  pdf:\n    toc: true\n")

--- a/checker/report.py
+++ b/checker/report.py
@@ -6,9 +6,11 @@ import json
 import shutil
 import subprocess
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+from checker import __version__
 
 SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 SEVERITY_ICON = {"error": "\033[31m❌\033[0m", "warning": "\033[33m⚠️\033[0m", "info": "ℹ️"}
@@ -60,6 +62,30 @@ class Finding:
         )
 
 
+@dataclass
+class LessonMetadata:
+    """Lesson identity for the report header, read from config.yaml and (if
+    present) CITATION.cff -- see lesson_check.read_lesson_metadata(). Purely
+    descriptive context for whoever reads the report, not a check result;
+    every field is optional since not every lesson has all of this filled
+    in (or a CITATION.cff at all)."""
+
+    title: str | None = None
+    carpentry: str | None = None  # friendly name, e.g. "Library Carpentry"
+    life_cycle: str | None = None
+    license: str | None = None
+    source: str | None = None
+    contact: str | None = None
+    created: str | None = None
+    authors: list[str] = field(default_factory=list)
+
+    def has_content(self) -> bool:
+        """Whether there's anything worth rendering -- false when config.yaml
+        itself was missing or empty, so the header block can be skipped
+        entirely rather than printed blank."""
+        return bool(self.title or self.carpentry or self.source or self.authors)
+
+
 def summarize(findings: list[Finding]) -> dict[str, int]:
     """Count findings per severity."""
     counts = {"error": 0, "warning": 0, "info": 0}
@@ -106,14 +132,52 @@ def _markdown_location_link(location: str, line: int | None, github_base: str | 
     return f"`{label}`"
 
 
+def _lesson_metadata_lines(
+    metadata: LessonMetadata | None, bold_open: str = "", bold_close: str = ""
+) -> list[str]:
+    """Plain-text lesson-identity lines shared by terminal/markdown: title
+    (wrapped in the caller's own bold markup), carpentry/life cycle/license
+    tags, source repo, authors, contact. Empty list if there's nothing to
+    show -- e.g. config.yaml was missing or empty."""
+    if metadata is None or not metadata.has_content():
+        return []
+    lines = []
+    header_bits = []
+    if metadata.title:
+        header_bits.append(f"{bold_open}{metadata.title}{bold_close}")
+    tags = [t for t in (metadata.carpentry,) if t]
+    if metadata.life_cycle:
+        tags.append(f"life cycle: {metadata.life_cycle}")
+    if metadata.license:
+        tags.append(f"license: {metadata.license}")
+    if tags:
+        header_bits.append(f"({', '.join(tags)})")
+    if header_bits:
+        lines.append(" ".join(header_bits))
+    if metadata.source:
+        lines.append(f"Source: {metadata.source}")
+    if metadata.authors:
+        lines.append(f"Authors: {', '.join(metadata.authors)}")
+    if metadata.contact:
+        lines.append(f"Contact: {metadata.contact}")
+    return lines
+
+
 def render_terminal(
-    findings: list[Finding], title: str, blame: dict[str, str] | None = None
+    findings: list[Finding],
+    title: str,
+    blame: dict[str, str] | None = None,
+    metadata: LessonMetadata | None = None,
 ) -> str:
     """Colored, grouped-by-location report for a terminal."""
     lines = [f"\033[1m{title}\033[0m"]
+    lines.extend(_lesson_metadata_lines(metadata, bold_open="\033[1m", bold_close="\033[0m"))
+    if metadata is not None and metadata.has_content():
+        lines.append("")
     counts = summarize(findings)
     lines.append(
-        f"{counts['error']} error(s), {counts['warning']} warning(s), {counts['info']} note(s)"
+        f"carpentries-workbench-checker v{__version__} · {counts['error']} error(s), "
+        f"{counts['warning']} warning(s), {counts['info']} note(s)"
     )
     if not findings:
         lines.append("\033[32m✅ No issues found\033[0m")
@@ -141,22 +205,32 @@ def render_markdown(
     title: str,
     blame: dict[str, str] | None = None,
     github_base: str | None = None,
+    metadata: LessonMetadata | None = None,
 ) -> str:
     """Checkbox-list report per location, ready to paste into a PR/issue.
 
     `github_base` (e.g. `https://github.com/org/repo/blob/<sha>`), when
     given, turns every location:line reference into a real clickable GitHub
-    link instead of plain text -- see `cli._github_blob_base`.
+    link instead of plain text -- see `cli._github_blob_base`. `metadata`
+    (see `LessonMetadata`), when given, adds a lesson-identity block (title,
+    carpentry, authors, ...) below the report title.
     """
     counts = summarize(findings)
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    lines = [
-        f"# {title}",
-        "",
-        f"Generated {generated} · {counts['error']} error(s), "
-        f"{counts['warning']} warning(s), {counts['info']} note(s)",
-        "",
-    ]
+    lines = [f"# {title}", ""]
+    metadata_lines = _lesson_metadata_lines(metadata, bold_open="**", bold_close="**")
+    if metadata_lines:
+        # Trailing double-space = a CommonMark/GFM hard line break, so these
+        # render as separate lines instead of collapsing into one reflowed
+        # paragraph (Markdown treats consecutive non-blank lines as the same
+        # paragraph otherwise).
+        lines.extend(f"{line}  " for line in metadata_lines)
+        lines.append("")
+    lines.append(
+        f"Generated {generated} by carpentries-workbench-checker v{__version__} · "
+        f"{counts['error']} error(s), {counts['warning']} warning(s), {counts['info']} note(s)"
+    )
+    lines.append("")
     if not findings:
         lines.append("All checks passed. Nothing to address before opening a PR.")
         return "\n".join(lines) + "\n"
@@ -203,11 +277,15 @@ def _anchor(location: str) -> str:
     return slug.replace(" ", "-")
 
 
-def render_json(findings: list[Finding], title: str) -> str:
+def render_json(
+    findings: list[Finding], title: str, metadata: LessonMetadata | None = None
+) -> str:
     """Machine-readable report, e.g. for a caller's own CI step."""
     payload = {
         "title": title,
         "generated": datetime.now(timezone.utc).isoformat(),
+        "generated_by": {"name": "carpentries-workbench-checker", "version": __version__},
+        "lesson": asdict(metadata) if metadata is not None else None,
         "summary": summarize(findings),
         "findings": [asdict(f) for f in findings],
     }

--- a/checker/report.py
+++ b/checker/report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -202,6 +203,88 @@ def render_terminal(
     return "\n".join(lines)
 
 
+_ANCHOR_STRIP_RE = re.compile(r"[^\w\s-]", re.UNICODE)
+
+
+def _anchor(text: str) -> str:
+    """Best-effort GitHub-flavored-markdown heading anchor: lowercase, strip
+    everything except word characters/spaces/hyphens, then spaces -> hyphens.
+    Used for file-path headings (`episodes/01-intro.md` -> a slug with no
+    `/`/`.`), matching GitHub's own algorithm closely enough for the paths
+    that actually appear here."""
+    slug = _ANCHOR_STRIP_RE.sub("", text.lower())
+    return re.sub(r"\s+", "-", slug.strip())
+
+
+def _group_by_category_and_hint(
+    items: list[Finding],
+) -> list[tuple[str, str | None, list[Finding]]]:
+    """Findings grouped by (category, exact shared `hint` text), largest
+    group first. Findings with no hint never merge with each other just
+    because both lack one -- each stays its own singleton, since two
+    unrelated problems that both happen to lack a hint are not the same
+    fix. Grouping is keyed on the literal `hint` string, not a stripped/
+    normalized `message` -- normalizing message text is what would
+    eventually merge unrelated findings or silently stop grouping when
+    wording changes elsewhere. Shared by the cross-file Action Summary
+    table and each file's detail section."""
+    hinted: dict[tuple[str, str], list[Finding]] = {}
+    singles: list[Finding] = []
+    for f in items:
+        if f.hint:
+            hinted.setdefault((f.category, f.hint), []).append(f)
+        else:
+            singles.append(f)
+    groups = sorted(hinted.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    result: list[tuple[str, str | None, list[Finding]]] = [
+        (category, hint, group_items) for (category, hint), group_items in groups
+    ]
+    result += [(f.category, None, [f]) for f in singles]
+    return result
+
+
+def _grouped_sections(
+    findings: list[Finding],
+) -> list[tuple[str, str, str | None, list[Finding]]]:
+    """Findings grouped into (severity, category, hint) patterns for the
+    Action Summary table: one row per exact shared corrective action,
+    ordered by severity (errors, then warnings, then notes), largest
+    pattern first within a severity. See `_group_by_category_and_hint` for
+    how a shared fix is identified."""
+    by_severity: dict[str, list[Finding]] = {}
+    for f in sorted(findings, key=Finding.sort_key):
+        by_severity.setdefault(f.severity, []).append(f)
+
+    sections = []
+    for severity, items in by_severity.items():
+        for category, hint, group_items in _group_by_category_and_hint(items):
+            sections.append((severity, category, hint, group_items))
+
+    sections.sort(key=lambda s: (SEVERITY_ORDER.get(s[0], 9), -len(s[3]), s[1]))
+    return sections
+
+
+def _render_file_finding_group(
+    hint: str | None, items: list[Finding], github_base: str | None, guide_link: str
+) -> list[str]:
+    """One blockquote within a file's section: a shared fix (if `hint` is
+    set) leading a checklist of every line in *this file* it applies to, or
+    -- for a hint-less singleton -- just that one finding. Each occurrence
+    line carries its own severity icon (a file section can mix severities,
+    unlike the old severity-scoped design). The guide link (once, not once
+    per occurrence) closes the block."""
+    lines = [f"> **Change:** {hint}", ">"] if hint else []
+    for f in items:
+        icon = SEVERITY_ICON_PLAIN.get(f.severity, "")
+        prefix = "- [ ]" if f.severity in ("error", "warning") else "-"
+        where = _markdown_location_link(f.location or "General", f.line, github_base)
+        lines.append(f"> {prefix} {icon} {where} — {f.message}")
+    if guide_link:
+        lines.append(">")
+        lines.append(f"> **Guide:**{guide_link}")
+    return lines
+
+
 def render_markdown(
     findings: list[Finding],
     title: str,
@@ -209,7 +292,13 @@ def render_markdown(
     github_base: str | None = None,
     metadata: LessonMetadata | None = None,
 ) -> str:
-    """Checkbox-list report per location, ready to paste into a PR/issue.
+    """PR/issue-ready report: a file-level checklist for triage, an Action
+    Summary of every shared fix pattern across the whole lesson (so a
+    repeated problem, e.g. 16 duplicate-heading warnings, is visible as one
+    row instead of scattered lines), then findings grouped file-first --
+    matching the order someone actually fixes them in an editor -- with
+    same-fix findings inside a file still collapsed into one change/
+    checklist rather than N separate cards.
 
     `github_base` (e.g. `https://github.com/org/repo/blob/<sha>`), when
     given, turns every location:line reference into a real clickable GitHub
@@ -241,8 +330,9 @@ def render_markdown(
     for f in sorted(findings, key=Finding.sort_key):
         by_location.setdefault(f.location or "General", []).append(f)
 
-    # File-level overview: one checkbox per location so progress is visible
-    # at a glance before scrolling into per-finding detail.
+    # File-level overview: which files need attention, linking down to that
+    # file's own detail section (file-first grouping below means a file
+    # again corresponds to exactly one section, same as pre-restructure).
     lines.append("## Files")
     lines.append("")
     for location, items in by_location.items():
@@ -252,31 +342,33 @@ def render_markdown(
         lines.append(f"{box} [{location}](#{_anchor(location)}) — {count_label}")
     lines.append("")
 
+    # Action summary: every shared-fix pattern across the whole lesson, so a
+    # problem repeated in many files (e.g. 16 duplicate-heading warnings) is
+    # visible as one row here even though the detail section below is
+    # file-first and will show it once per file. No deep links -- a
+    # cross-file pattern has no single section it "belongs" to.
+    lines.append("## Action summary")
+    lines.append("")
+    lines.append("| Priority | What to change | Occurrences | Files |")
+    lines.append("|---|---|---:|---:|")
+    for severity, _category, hint, items in _grouped_sections(findings):
+        icon = SEVERITY_ICON_PLAIN.get(severity, "")
+        what = hint or items[0].message
+        n_files = len({f.location for f in items if f.location})
+        lines.append(f"| {icon} {severity.capitalize()} | {what} | {len(items)} | {n_files} |")
+    lines.append("")
+
+    # Detail section: file-first, matching the order someone actually fixes
+    # things in an editor. Within a file, same-fix findings still collapse
+    # into one change/checklist instead of N separate cards.
     for location, items in by_location.items():
         lines.append(f"## {location}{_blame_suffix(location, blame)}")
         lines.append("")
-        for f in items:
-            icon = SEVERITY_ICON_PLAIN.get(f.severity, "")
-            box = "- [ ]" if f.severity in ("error", "warning") else "-"
-            where = _markdown_location_link(location, f.line, github_base)
-            entry = f"{box} {icon} {where} **{f.category}** — {f.message}"
-            lines.append(entry)
-            if f.hint:
-                lines.append(f"      *Fix:* {f.hint}{_guide_link_markdown(f.category)}")
-            elif f.category in CATEGORY_GUIDE_LINKS:
-                lines.append(f"      *Guide:*{_guide_link_markdown(f.category)}")
-        lines.append("")
+        for _category, hint, group_items in _group_by_category_and_hint(items):
+            guide_link = _guide_link_markdown(group_items[0].category)
+            lines.extend(_render_file_finding_group(hint, group_items, github_base, guide_link))
+            lines.append("")
     return "\n".join(lines)
-
-
-def _anchor(location: str) -> str:
-    """Best-effort GitHub-flavored-markdown heading anchor for a `## location`
-    heading, used by the file-overview checklist's links. GFM lowercases,
-    strips non-word/non-hyphen/non-space characters, and turns spaces into
-    hyphens; this covers lesson-path headings (letters, digits, `/`, `.`,
-    `-`, `_`), which is everything that actually appears here."""
-    slug = location.lower().replace("/", "").replace(".", "").replace("_", "-")
-    return slug.replace(" ", "-")
 
 
 def render_json(

--- a/checker/report.py
+++ b/checker/report.py
@@ -10,6 +10,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+import yaml
+
 from checker import __version__
 
 SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
@@ -292,7 +294,16 @@ def render_json(
     return json.dumps(payload, indent=2)
 
 
-def _render_via_quarto(markdown_text: str, out_path: Path, to: str, format_yaml: str) -> Path | None:
+# Pandoc format options per target, keyed the same as quarto's own `--to`.
+_QUARTO_FORMAT_OPTIONS: dict[str, dict] = {
+    "html": {"toc": True, "embed-resources": True},
+    "pdf": {"toc": True},
+}
+
+
+def _render_via_quarto(
+    markdown_text: str, out_path: Path, to: str, report_title: str
+) -> Path | None:
     """Shared by render_html_via_quarto/render_pdf_via_quarto: write the report
     as a .qmd with the given pandoc `format:` block, render it to `to`
     ("html"/"pdf"), and copy the result to out_path. Returns None if quarto
@@ -312,9 +323,15 @@ def _render_via_quarto(markdown_text: str, out_path: Path, to: str, format_yaml:
         # cwd we gave it, failing with a permission error on /private.
         tmp_dir = Path(tmp).resolve()
         qmd_path = tmp_dir / "report.qmd"
-        qmd_path.write_text(
-            f"---\ntitle: Lesson Check Report\nformat:\n{format_yaml}---\n\n" + markdown_text
+        # yaml.safe_dump, not an f-string, because report_title is a lesson's
+        # actual title -- arbitrary text that can contain colons, quotes, or
+        # unicode that would otherwise break the YAML front matter.
+        front_matter = yaml.safe_dump(
+            {"title": report_title, "format": {to: _QUARTO_FORMAT_OPTIONS[to]}},
+            sort_keys=False,
+            allow_unicode=True,
         )
+        qmd_path.write_text(f"---\n{front_matter}---\n\n" + markdown_text)
         result = subprocess.run(
             ["quarto", "render", str(qmd_path), "--to", to, "-o", out_path.name],
             cwd=tmp_dir,
@@ -328,19 +345,21 @@ def _render_via_quarto(markdown_text: str, out_path: Path, to: str, format_yaml:
     return out_path
 
 
-def render_html_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
+def render_html_via_quarto(
+    markdown_text: str, out_path: Path, report_title: str = "Lesson Check Report"
+) -> Path | None:
     """Render a markdown report to HTML with Quarto, if it's installed. See
     `_render_via_quarto` for the None/RuntimeError contract."""
-    return _render_via_quarto(
-        markdown_text, out_path, "html", "  html:\n    toc: true\n    embed-resources: true\n"
-    )
+    return _render_via_quarto(markdown_text, out_path, "html", report_title)
 
 
-def render_pdf_via_quarto(markdown_text: str, out_path: Path) -> Path | None:
+def render_pdf_via_quarto(
+    markdown_text: str, out_path: Path, report_title: str = "Lesson Check Report"
+) -> Path | None:
     """Render a markdown report to PDF with Quarto, if it's installed and a
     LaTeX distribution is available (`quarto install tinytex`, or an existing
     MacTeX/TeX Live install on PATH). See `_render_via_quarto` for the
     None/RuntimeError contract -- a missing LaTeX engine surfaces as a
     RuntimeError with quarto's own error text, not a silent None, since
     quarto being on PATH doesn't guarantee PDF rendering works."""
-    return _render_via_quarto(markdown_text, out_path, "pdf", "  pdf:\n    toc: true\n")
+    return _render_via_quarto(markdown_text, out_path, "pdf", report_title)

--- a/design/future-work-guide-citations-2026-08-31.md
+++ b/design/future-work-guide-citations-2026-08-31.md
@@ -1,0 +1,90 @@
+# Future work: precise guide citations per check
+
+Not started -- captured so whoever picks it up doesn't have to re-research
+the source material. `CATEGORY_GUIDE_LINKS` in `checker/report.py` currently
+maps each check category to one static, whole-page link:
+
+```python
+CATEGORY_GUIDE_LINKS: dict[str, tuple[str, str]] = {
+    "config": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "front-matter": ("Episode front matter", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "divs": ("Workbench Component Guide", "https://carpentries.github.io/sandpaper-docs/component-guide.html"),
+    "headings": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "links": ("Episodes and lesson structure", "https://carpentries.github.io/sandpaper-docs/episodes.html"),
+    "objectives": ("CLDT: SMART objectives", "https://carpentries.github.io/lesson-development-training/aio.html"),
+    "style": ("Carpentries Lab reviewer checklist", "https://github.com/carpentries-lab/reviews/blob/main/docs/reviewer_guide.md"),
+}
+```
+
+Five different categories (`config`, `front-matter`, `divs`, `headings`,
+`links`) all point at the same generic sandpaper-docs page, and `style`
+links to the top of `reviewer_guide.md` with no anchor even though the
+checklist inside it is sectioned. The goal: cite the most specific real
+source per check, not the closest generic one.
+
+## What's actually in carpentries-lab/reviews
+
+Pulled and read directly (2026-08-31), not from memory:
+
+- **`docs/reviewer_guide.md`** -- has a real `## Reviewer Checklist` with
+  anchored subsections: `#accessibility`, `#content`, `#design`,
+  `#supporting-information`, `#general`. `#accessibility` explicitly calls
+  out contractions ("does not make extensive use of contractions") --
+  this is a direct, exact match for our `style` check, which currently
+  links to the whole file instead of `#accessibility`.
+- **`docs/templates/review_template.md`** -- the same checklist, no prose
+  around it, meant to be copy-pasted by a Lab reviewer. Same content as
+  reviewer_guide.md's checklist, just without the surrounding process
+  explanation.
+- **`docs/editor_guide.md`** -- a *second*, more precise checklist (what a
+  Lab Editor checks before review). Directly relevant, more specific than
+  what we currently cite in several places:
+  - `#accessibility`: "h2 is used for sections," "no 'jumps' ... e.g.
+    h2->h4," "no page contains more than one h1 element." This states our
+    `headings` category's rules more precisely than the generic
+    sandpaper-docs episodes.html page we currently cite for it.
+  - `#structure`: "Estimated times are included... Episode lengths are
+    appropriate for management of cognitive load" -- matches our
+    `front-matter` episode-length (20-60 min) check.
+  - `#content`: "All non-discussion exercises have solutions" -- matches
+    our `divs` category's "N challenge(s) but 0 solution(s)" check.
+  - `#supporting-information`: "a glossary of key terms or links out to
+    definitions" -- matches our glossary-existence check (currently filed
+    under `config`).
+  - `#design`: "Learning objectives are defined for the lesson and every
+    episode" -- another legitimate citation for `objectives`, alongside
+    CLDT.
+- **`docs/author_guide.md`** -- checked, not useful here. It's the
+  submission-process checklist (lesson title, repo URLs, DOI, JOSE
+  submission, code-of-conduct/license/template confirmation) that authors
+  fill out when *submitting* to Carpentries Lab for review -- not content-
+  quality guidance. Doesn't map to any of our checks.
+
+## Proposed remapping (needs real editorial judgment, not a find-replace)
+
+| Category | Current link | Proposed |
+|---|---|---|
+| `style` | `reviewer_guide.md` (top) | `reviewer_guide.md#accessibility` |
+| `headings` | sandpaper-docs episodes.html | keep as primary (it's the mechanical-rule source Workbench itself enforces) + add `editor_guide.md#accessibility` as a secondary "why" citation, since it states the exact rule set more precisely |
+| `objectives` | CLDT aio.html only | keep CLDT + add `reviewer_guide.md#design` or `editor_guide.md#design` |
+| glossary check (currently `config`) | sandpaper-docs episodes.html | `reviewer_guide.md#supporting-information` or `editor_guide.md#supporting-information` |
+| `divs` (challenge/solution count) | component-guide.html | keep for div syntax + add `editor_guide.md#content` for the "solutions required" rule specifically |
+
+`CATEGORY_GUIDE_LINKS` is currently `category -> one (label, url)` tuple.
+Supporting a primary + secondary citation per category (or per specific
+check within a category, since e.g. `headings` covers three different
+rules with three different best sources) means either allowing a list of
+tuples per category, or moving citation choice down to the individual
+`Finding`'s `hint` construction in `lesson_check.py` instead of a
+category-wide default in `report.py`. Worth deciding before implementing,
+not deciding while implementing.
+
+## Bonus finding: a possible new check, not just a citation fix
+
+`editor_guide.md#accessibility` states "no 'jumps' ... e.g. h2->h4" as a
+rule. `_check_headings` in `lesson_check.py` currently checks "first
+heading must be level 2" and "no duplicate headings," but does **not**
+check for a level *skip* mid-document (e.g. a real `h2` followed later by
+an `h4` with no `h3` in between). This is a real gap against Carpentries'
+own stated rule, separate from the citation-accuracy work above -- flagged
+here, not scoped or built.

--- a/design/future-work-lifecycle-guidance-2026-08-31.md
+++ b/design/future-work-lifecycle-guidance-2026-08-31.md
@@ -1,0 +1,93 @@
+# Future work: lesson lifecycle "what's next" guidance
+
+Not started. Idea: since the checker already reads `life_cycle` from
+`config.yaml` (`LessonMetadata.life_cycle`, via `read_lesson_metadata`) and
+already computes error/warning/note counts, it could tell the author what
+concretely stands between the lesson and its next lifecycle stage, instead
+of just reporting `life_cycle` as a fact in the header.
+
+## The actual stages and criteria
+
+Source: https://docs.carpentries.org/resources/curriculum/lesson-life-cycle.html
+(fetched and quoted 2026-08-31, not from memory).
+
+| Stage | Advances to next when | Verbatim |
+|---|---|---|
+| Pre-alpha -> Alpha | a first draft is complete | "This label is typically applied to a lesson until a first draft has been completed." |
+| Alpha -> Beta | developers are confident it's ready for other instructors to pilot | "This label is typically applied to a lesson after its first draft has been completed, and before the first pilot workshops take place" |
+| Beta -> Stable | feedback from beta pilot workshops has been incorporated | "This label is typically applied to a lesson after feedback from beta pilot workshops has been incorporated." |
+
+**Who approves the change matters and differs by lesson type** -- worth
+surfacing since Tim's own lessons are mostly Incubator/Library Carpentry,
+not official program lessons:
+
+- **Incubator lessons** (most of what's in `~/projects/lessons/content`):
+  self-declared. "lesson developers are free to choose whichever label
+  they feel is appropriate."
+- **Carpentries Lab lessons**: should already be marked stable after peer
+  review (the Lab review process, see `future-work-guide-citations-2026-08-31.md`,
+  gates this).
+- **Official Carpentries program lessons** (Library/Data/Software
+  Carpentry): needs "consultation with the relevant Curriculum Advisory
+  Committee and/or the Curriculum Team" -- not something a local tool can
+  verify or grant.
+
+## What's actually machine-checkable here (and what isn't)
+
+Two of the three transitions have decent automatable proxies using data
+the checker already has. The third does not, and shouldn't be faked:
+
+- **Pre-alpha -> Alpha** ("first draft complete"): reasonable proxy =
+  zero `boilerplate`-category findings (no unwritten scaffold episodes or
+  placeholder support files left). This is exactly what `boilerplate`
+  already checks for.
+- **Alpha -> Beta** ("confident it's ready for other instructors to
+  pilot"): reasonable proxy = zero `error`-severity findings, and ideally
+  a low/zero `warning` count. Not a perfect proxy (confidence is a human
+  judgment) but a defensible "here's what's still rough" signal.
+- **Beta -> Stable** ("beta pilot feedback incorporated"): **not
+  checkable at all** from repo content -- this requires knowing whether a
+  pilot happened and whether feedback was addressed, information this
+  tool has no access to. Any implementation should say something like "no
+  mechanical check applies here -- this is a human judgment call based on
+  pilot feedback," not silently omit stage-3 guidance or fake a check.
+
+## Sketch of the feature (not designed in detail, just the shape)
+
+A new section in the report (terminal/markdown/HTML/PDF), something like:
+
+```
+## Next steps: pre-alpha -> alpha
+
+3 boilerplate finding(s) remain (unwritten scaffold). Clear these to reach
+alpha ("first draft complete"). See the Files/Action Summary above for
+which ones.
+```
+
+or, if already past what's checkable:
+
+```
+## Next steps: alpha -> beta
+
+0 errors, 2 warnings remaining. Close to ready for outside instructors to
+pilot -- the 2 warnings above are worth a look first.
+```
+
+or, at beta:
+
+```
+## Next steps: beta -> stable
+
+No mechanical check applies -- this stage advances once feedback from a
+beta pilot workshop has been incorporated, which only you know the status
+of.
+```
+
+Open questions for whoever builds this, not resolved here:
+
+- Does this replace or sit alongside the existing lesson-metadata block?
+- Does it need its own CLI flag (e.g. `--next-steps`) or is it always-on
+  given metadata is already always-on?
+- Should the Incubator-vs-official-program distinction change the wording
+  (self-declare vs "needs Curriculum Team consultation")? `LessonMetadata`
+  already has `carpentry` (lc/dc/swc/cp/incubator) to key off of.

--- a/design/validation-prompt-report-scannability-2026-08-31.md
+++ b/design/validation-prompt-report-scannability-2026-08-31.md
@@ -1,0 +1,210 @@
+# Validation request: report output format is hard to scan
+
+## What this project is
+
+`carpentries-workbench-checker` is a small internal CLI tool (UCLA IMLS
+Open Science / UC OSPO Network programs) that Carpentries Workbench lesson
+authors run locally before pushing, to catch structural/pedagogical
+problems before waiting on the real CI build. It runs deterministic checks
+(front matter, required divs, headings, links, objective quality,
+boilerplate/placeholder detection, contractions, etc.) against a lesson
+repo and produces a report someone reads to decide what to fix. It is not
+being redesigned architecturally this round -- this round is narrowly about
+**how the findings are laid out on the page**, because a real user found
+the current layout hard to scan.
+
+## The complaint, verbatim
+
+> "let's /validate-external on the output format for this report, e.g. the
+> task lists as one line, without structure below that. it is hard to read
+> by me. i want something ppl can scan and see what is off, what needs to
+> change, etc."
+
+This is the person who actually reads these reports (a UCLA library
+director reviewing lesson repos, sometimes handing the PDF to a lesson
+maintainer who isn't in this codebase at all). "One line, no structure
+below it" and "hard to scan" are the two concrete complaints to solve for.
+
+## The current design (exact code + a real example)
+
+Findings are a flat dataclass: `severity` (error/warning/info), `category`
+(config/front-matter/divs/headings/links/objectives/style/boilerplate),
+`message`, `location`, optional `hint`, optional `line`. The markdown
+renderer (`checker/report.py::render_markdown`, the source both the
+plain-markdown output and the Quarto-rendered HTML/PDF come from) groups
+findings by file, then emits each one as a single bullet line plus an
+optional indented italic line underneath:
+
+```python
+for location, items in by_location.items():
+    lines.append(f"## {location}{_blame_suffix(location, blame)}")
+    lines.append("")
+    for f in items:
+        icon = SEVERITY_ICON_PLAIN.get(f.severity, "")
+        box = "- [ ]" if f.severity in ("error", "warning") else "-"
+        where = _markdown_location_link(location, f.line, github_base)
+        entry = f"{box} {icon} {where} **{f.category}** — {f.message}"
+        lines.append(entry)
+        if f.hint:
+            lines.append(f"      *Fix:* {f.hint}{_guide_link_markdown(f.category)}")
+        elif f.category in CATEGORY_GUIDE_LINKS:
+            lines.append(f"      *Guide:*{_guide_link_markdown(f.category)}")
+    lines.append("")
+```
+
+Real output, from a just-generated report against a live lesson
+(`librarycarpentry/lc-r`), unedited:
+
+```markdown
+## episodes/01-intro-to-r.Rmd
+
+- [ ] ⚠️ [episodes/01-intro-to-r.Rmd:228](https://github.com/.../01-intro-to-r.Rmd#L228) **headings** — heading `Exercise` on line 228 duplicates the one on line 175
+      *Guide:* [Episodes and lesson structure](https://carpentries.github.io/sandpaper-docs/episodes.html)
+- [ ] ⚠️ [episodes/01-intro-to-r.Rmd:236](https://github.com/.../01-intro-to-r.Rmd#L236) **headings** — heading `Solution` on line 236 duplicates the one on line 182
+      *Guide:* [Episodes and lesson structure](https://carpentries.github.io/sandpaper-docs/episodes.html)
+- [ ] ⚠️ [episodes/01-intro-to-r.Rmd:662](https://github.com/.../01-intro-to-r.Rmd#L662) **headings** — heading `Exercise` on line 662 duplicates the one on line 175
+      *Guide:* [Episodes and lesson structure](https://carpentries.github.io/sandpaper-docs/episodes.html)
+```
+
+Rendered (HTML/PDF via a Quarto custom-format extension, same markdown
+source): each finding is one paragraph-height line -- checkbox, small
+emoji, a blue link, a bold category word, an em dash, then the message, all
+run together left-to-right -- followed by an indented, italicized "Fix:" or
+"Guide:" line in smaller visual weight than the finding itself. There is no
+table, no columns, no visual separation between "what's wrong" and "what
+to do about it" beyond that one line being indented and italic.
+
+At the top of the whole report there IS a scannable piece: a **Files**
+checklist (one line per file, `- [ ] path — N issue(s)`), so file-level
+triage already works. The complaint is specifically about the
+**per-finding detail underneath each file heading**.
+
+**A real scale data point**: in the `lc-r` example above, 14 of that
+lesson's 22 warnings are the exact same root cause (a `Solution`/`Exercise`
+heading reused across challenges instead of given unique text) -- but the
+current layout presents all 14 as visually identical, independent
+one-liners grouped by *file*, so the fact that it's one repeated pattern
+across the whole lesson doesn't show at a glance; a reader has to notice it
+themselves by reading 14 near-identical lines.
+
+## What's already decided -- don't relitigate
+
+- The underlying `Finding` data model (severity/category/message/location/
+  hint/line) is fixed for this round. This is a rendering-layer question,
+  not a data-model question.
+- Terminal and JSON output formats are not part of this complaint (only
+  markdown/HTML/PDF, which share the same `render_markdown` source) and
+  aren't being touched.
+- The Quarto custom-format-extension architecture (`_extensions/checker-report/`,
+  which owns theme/colors/margins) stays. This round is about markdown
+  *structure* (what elements exist: bullets vs. tables vs. definition
+  lists vs. `<details>` blocks), which the extension's CSS/LaTeX can then
+  style -- not about switching rendering pipelines.
+- GitHub blob deep-linking (`path:line` -> a real `#L42` GitHub URL) and
+  the file-level checklist at the top both work and should be kept.
+- Severity icons (❌/⚠️/ℹ️) and the checkbox-vs-bullet distinction
+  (actionable vs. info-only) should be kept as signals, just not
+  necessarily rendered the same way.
+
+## Specific questions -- please give concrete answers, not general advice
+
+1. **Is grouping by file the wrong primary grouping for scannability?**
+   Given the real example above (14/22 warnings are one repeated pattern),
+   would grouping by *category* first (all "duplicate heading" findings
+   together, so the repetition is visually obvious as one pattern instead
+   of 14 separate lines) -- with file:line as a sub-detail -- surface "what
+   needs to change" faster than the current file-first grouping? Or is
+   file-first still right because the reader fixes one file at a time
+   regardless of how many categories it touches?
+
+2. **Should each finding be a table row instead of a bullet + indented
+   line?** A markdown table (`| ⚠️ | file:line | category | message | fix |`)
+   would put "what's wrong" and "what to do" in separate columns a reader's
+   eye can scan down, instead of one run-on line. Concrete downsides to
+   weigh: table cells can't easily wrap a long message/fix without getting
+   unreadable in a narrow terminal-width markdown viewer (e.g. GitHub's PR
+   diff view, VS Code's default markdown preview), and long URLs inside
+   table cells break table alignment in plain-text markdown. Is a table the
+   right call here, and if column width is the real risk, what's the
+   concrete alternative (definition list? two-line card format with a
+   visual left border per finding? HTML `<dl>` since this already renders
+   through Quarto/pandoc which allows raw HTML)?
+
+3. **Should "Fix:" stop being a trailing italic line and become the
+   visually primary element?** Right now the *problem* description reads
+   first, in full sentence form, and the *fix* is secondary and smaller.
+   For someone who just wants to know "what do I change," should the fix
+   text lead (e.g. bold imperative first: "**Give this Solution a unique
+   heading**" then the detail below), rather than leading with a passive
+   description of what's wrong?
+
+4. **What's the concrete "scannable" structure you'd actually ship**, given
+   this renders through Quarto/pandoc (so raw HTML in the markdown source
+   is available, e.g. `<details>`/`<summary>` for collapsible per-file or
+   per-category sections, `<dl>` definition lists, or CSS classes the
+   `checker-report` Quarto extension can style)? Please show a redrafted
+   example of the exact `lc-r` excerpt above (the 3 duplicate-heading
+   findings, plus the one `config.yaml` error) in your proposed structure,
+   not just a description of the idea.
+
+5. **Confidence score (1-10)** on your top recommendation, and what would
+   most likely prove it wrong (e.g. "this only helps if most lessons have
+   >1 finding per category, small lessons with 2-3 total findings won't
+   benefit and the extra structure is overhead").
+
+Please give concrete corrections (real restructured markdown/HTML
+examples, not descriptions of formats) so they can go through an
+adopt/reject pass against the actual codebase before anything changes.
+
+## Outcome
+
+Two rounds. Round 1 (general UX advice) recommended severity -> category ->
+shared-fix grouping for the whole detail section, replacing file-first
+entirely. Built and tested it -- worked, verified via a real render through
+`checker-report` (Quarto extension) that nested checkboxes and headings
+inside a `>` blockquote render correctly in both HTML and PDF. Two things
+were caught during that verification, not proposed corrections: (1) a
+severity emoji inside a `##`/`###` heading breaks in PDF -- LaTeX's font has
+no glyph for it, renders as a broken box in both the heading and the PDF
+TOC, so the shipped design keeps emoji inline in body text only, never in
+headings; (2) the reviewer's worked example invented a `config.yaml`
+finding ("keywords still template default") that this tool doesn't actually
+check -- the real finding in that same data was `contact`, not `keywords`.
+Not adopted as presented; real data substituted.
+
+Round 2, run independently by the user with actual usability-research
+citations (Johnson et al. ICSE 2013, Nachtigall et al. ISSTA 2022, GOV.UK's
+error-summary pattern, Google's Tricorder), revised the recommendation:
+keep the *detail* section file-first (matches the actual editing workflow --
+someone with one file open in an editor wants everything about that file in
+one place, not scattered across category sections), and let a new top-level
+pattern-summary table do the "is this one repeated problem" job instead.
+The GOV.UK citation is real and relevant but was validated for a form
+corrected in place on the same page; this report is read once then acted on
+elsewhere, so the transfer isn't exact -- the citation's own evidence table
+rated file-vs-category grouping "moderate, not directly tested," same
+strength either way.
+
+**Final shape shipped** (splits the difference, keeps what both rounds
+independently agreed on): Files checklist (unchanged) -> a cross-lesson
+Action Summary table, one row per exact shared `hint`, not one row per
+finding or per file -> file-first detail sections, each `## location`, with
+findings inside a file that share an exact `hint` still collapsed into one
+`**Change:**` + occurrence checklist + single `**Guide:**` line rather than
+N separate cards. Grouping key is the literal `hint` string throughout,
+never normalized `message` text (both rounds agreed stripping/normalizing
+message text would eventually merge unrelated findings or silently stop
+grouping when wording changed).
+
+Verified against a live example (`librarycarpentry/lc-r`): the busiest file
+(`episodes/01-intro-to-r.Rmd`, 8 findings) collapsed from 8 separate lines
+to 3 blocks (7 duplicate-heading warnings -> 1 change-group, plus 2
+one-offs), and the lesson-wide 16-occurrence duplicate-heading pattern
+across 4 files shows as one Action Summary row. `checker/lesson_check.py`,
+`checker/report.py`, `README.md`, `tests/test_report.py` updated; 142/142
+tests passing (13 new, covering the grouping logic directly plus the
+rendered structure). One follow-up not done this round: several existing
+`hint` strings (the CLDT ones) read as explanatory sentences rather than
+short imperatives, which makes them long in the Action Summary table's
+"What to change" column -- a content pass on hint wording, not a rendering
+change, flagged but out of scope here.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from checker.cli import _blame_map, _read_glossary
+from checker import cli
+from checker.cli import _blame_map, _github_blob_base, _read_glossary, main
 from checker.report import Finding
 
 
@@ -94,3 +95,86 @@ def test_read_glossary_falls_back_to_legacy_root_path(tmp_path):
     content = "# Reference\n\nCopyleft\n: Requires derivative works stay open.\n"
     (tmp_path / "reference.md").write_text(content)
     assert _read_glossary(tmp_path) == content
+
+
+# -- GitHub blob base URL, for clickable line links in the markdown report --
+
+
+def _commit_something(path: Path):
+    (path / "episodes").mkdir()
+    (path / "episodes" / "ep.md").write_text("content\n")
+    subprocess.run(["git", "add", "episodes/ep.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add episode"], cwd=path, check=True)
+
+
+def test_github_blob_base_https_remote(tmp_path):
+    _init_git_repo(tmp_path)
+    _commit_something(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/org/repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert _github_blob_base(tmp_path) == f"https://github.com/org/repo/blob/{sha}"
+
+
+def test_github_blob_base_ssh_remote(tmp_path):
+    _init_git_repo(tmp_path)
+    _commit_something(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:org/repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert _github_blob_base(tmp_path) == f"https://github.com/org/repo/blob/{sha}"
+
+
+def test_github_blob_base_not_a_git_repo_is_none(tmp_path):
+    assert _github_blob_base(tmp_path) is None
+
+
+def test_github_blob_base_no_remote_is_none(tmp_path):
+    _init_git_repo(tmp_path)
+    _commit_something(tmp_path)
+    assert _github_blob_base(tmp_path) is None
+
+
+def test_github_blob_base_non_github_remote_is_none(tmp_path):
+    _init_git_repo(tmp_path)
+    _commit_something(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://gitlab.com/org/repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    assert _github_blob_base(tmp_path) is None
+
+
+# -- --open flag ---------------------------------------------------------------
+
+
+def test_open_flag_launches_browser_on_successful_render(tmp_path, monkeypatch):
+    opened = []
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli.webbrowser, "open", lambda uri: opened.append(uri))
+    out = tmp_path / "report.html"
+    out.write_text("<html></html>")
+    main([str(tmp_path), "--html", "--open", "--output", str(tmp_path / "report.md")])
+    assert opened == [out.resolve().as_uri()]
+
+
+def test_open_flag_without_html_prints_notice(tmp_path, capsys):
+    main([str(tmp_path), "--open", "--output", str(tmp_path / "report.md")])
+    assert "--open has no effect without --html" in capsys.readouterr().err
+
+
+def test_open_flag_when_quarto_missing_prints_nothing_to_open(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, _out_path: None)
+    main([str(tmp_path), "--html", "--open", "--output", str(tmp_path / "report.md")])
+    assert "no HTML file was rendered" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,7 +161,7 @@ def test_github_blob_base_non_github_remote_is_none(tmp_path):
 
 def test_open_flag_launches_browser_on_successful_render(tmp_path, monkeypatch):
     opened = []
-    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path, **_kw: out_path)
     monkeypatch.setattr(cli.webbrowser, "open", lambda uri: opened.append(uri))
     out = tmp_path / "report.html"
     out.write_text("<html></html>")
@@ -175,7 +175,7 @@ def test_open_flag_without_html_prints_notice(tmp_path, capsys):
 
 
 def test_open_flag_when_quarto_missing_prints_nothing_to_open(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, _out_path: None)
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, _out_path, **_kw: None)
     main([str(tmp_path), "--html", "--open", "--output", str(tmp_path / "report.md")])
     assert "no HTML file was rendered" in capsys.readouterr().err
 
@@ -184,25 +184,25 @@ def test_open_flag_when_quarto_missing_prints_nothing_to_open(tmp_path, monkeypa
 
 
 def test_pdf_flag_writes_rendered_pdf(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path, **_kw: out_path)
     main([str(tmp_path), "--pdf", "--output", str(tmp_path / "report.md")])
     assert f"wrote {tmp_path / 'report.pdf'}" in capsys.readouterr().err
 
 
 def test_pdf_flag_default_output_name_has_no_markdown_output(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path, **_kw: out_path)
     main([str(tmp_path), "--pdf"])
     assert "wrote report.pdf" in capsys.readouterr().err
 
 
 def test_pdf_flag_when_quarto_missing_prints_notice(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, _out_path: None)
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, _out_path, **_kw: None)
     main([str(tmp_path), "--pdf", "--output", str(tmp_path / "report.md")])
     assert "quarto not found on PATH -- skipping PDF render" in capsys.readouterr().err
 
 
 def test_pdf_flag_when_render_fails_prints_error(tmp_path, monkeypatch, capsys):
-    def _raise(_md_text, _out_path):
+    def _raise(_md_text, _out_path, **_kw):
         raise RuntimeError("no LaTeX installation found")
 
     monkeypatch.setattr(cli, "render_pdf_via_quarto", _raise)
@@ -213,9 +213,35 @@ def test_pdf_flag_when_render_fails_prints_error(tmp_path, monkeypatch, capsys):
 
 
 def test_html_and_pdf_flags_together_both_render(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path: out_path)
-    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path, **_kw: out_path)
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path, **_kw: out_path)
     main([str(tmp_path), "--html", "--pdf", "--output", str(tmp_path / "report.md")])
     err = capsys.readouterr().err
     assert f"wrote {tmp_path / 'report.html'}" in err
     assert f"wrote {tmp_path / 'report.pdf'}" in err
+
+
+def test_html_render_receives_lesson_title_as_report_title(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text("title: 'Python Intro'\n")
+    captured = {}
+
+    def _capture(_md_text, out_path, **kw):
+        captured.update(kw)
+        return out_path
+
+    monkeypatch.setattr(cli, "render_html_via_quarto", _capture)
+    main([str(tmp_path), "--html", "--output", str(tmp_path / "report.md")])
+    assert captured["report_title"] == "Python Intro — Lesson Check Report"
+
+
+def test_html_render_falls_back_to_default_title_when_no_lesson_title(tmp_path, monkeypatch):
+    captured = {}
+
+    def _capture(_md_text, out_path, **kw):
+        captured.update(kw)
+        return out_path
+
+    monkeypatch.setattr(cli, "render_html_via_quarto", _capture)
+    main([str(tmp_path), "--html", "--output", str(tmp_path / "report.md")])
+    assert captured["report_title"].startswith("Lesson Check Report")
+    assert "Python Intro" not in captured["report_title"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,3 +178,44 @@ def test_open_flag_when_quarto_missing_prints_nothing_to_open(tmp_path, monkeypa
     monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, _out_path: None)
     main([str(tmp_path), "--html", "--open", "--output", str(tmp_path / "report.md")])
     assert "no HTML file was rendered" in capsys.readouterr().err
+
+
+# -- --pdf flag ------------------------------------------------------------
+
+
+def test_pdf_flag_writes_rendered_pdf(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    main([str(tmp_path), "--pdf", "--output", str(tmp_path / "report.md")])
+    assert f"wrote {tmp_path / 'report.pdf'}" in capsys.readouterr().err
+
+
+def test_pdf_flag_default_output_name_has_no_markdown_output(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    main([str(tmp_path), "--pdf"])
+    assert "wrote report.pdf" in capsys.readouterr().err
+
+
+def test_pdf_flag_when_quarto_missing_prints_notice(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, _out_path: None)
+    main([str(tmp_path), "--pdf", "--output", str(tmp_path / "report.md")])
+    assert "quarto not found on PATH -- skipping PDF render" in capsys.readouterr().err
+
+
+def test_pdf_flag_when_render_fails_prints_error(tmp_path, monkeypatch, capsys):
+    def _raise(_md_text, _out_path):
+        raise RuntimeError("no LaTeX installation found")
+
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", _raise)
+    main([str(tmp_path), "--pdf", "--output", str(tmp_path / "report.md")])
+    err = capsys.readouterr().err
+    assert "quarto render failed, skipping PDF output" in err
+    assert "no LaTeX installation found" in err
+
+
+def test_html_and_pdf_flags_together_both_render(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "render_html_via_quarto", lambda _md_text, out_path: out_path)
+    monkeypatch.setattr(cli, "render_pdf_via_quarto", lambda _md_text, out_path: out_path)
+    main([str(tmp_path), "--html", "--pdf", "--output", str(tmp_path / "report.md")])
+    err = capsys.readouterr().err
+    assert f"wrote {tmp_path / 'report.html'}" in err
+    assert f"wrote {tmp_path / 'report.pdf'}" in err

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -171,6 +171,15 @@ def test_divs_unclosed_is_error():
     assert any("never closed" in f.message for f in findings)
 
 
+def test_divs_unclosed_has_structured_line_number():
+    # The line field must be populated, not just embedded in the message --
+    # renderers need it as data to build clickable links.
+    body = ":::: challenge\nNo closing fence.\n"
+    findings = _check_divs(body, "ep.md")
+    matches = [f for f in findings if "never closed" in f.message]
+    assert matches and matches[0].line == 1
+
+
 def test_divs_extraneous_close_is_error():
     body = "Some text.\n:::\n"
     findings = _check_divs(body, "ep.md")
@@ -201,6 +210,12 @@ def test_headings_level_one_is_error():
     assert any(f.severity == "error" for f in findings)
 
 
+def test_headings_level_one_has_structured_line_number():
+    findings = _check_headings("# Top level\n\n## Ok\n", "ep.md")
+    matches = [f for f in findings if f.severity == "error"]
+    assert matches and matches[0].line == 1
+
+
 def test_headings_first_not_level_two_is_warning():
     findings = _check_headings("### Starts too deep\n", "ep.md")
     assert any("expected level 2" in f.message for f in findings)
@@ -229,6 +244,7 @@ def test_links_image_missing_alt_and_missing_file(tmp_path):
     messages = [f.message for f in findings]
     assert any("no alt text" in m for m in messages)
     assert any("missing file" in m for m in messages)
+    assert all(f.line == 1 for f in findings)
 
 
 def test_links_episode_relative_fig_image_resolves(tmp_path):
@@ -461,6 +477,7 @@ def test_placeholder_bullets_keypoint_variants_are_flagged():
     findings = _check_placeholder_bullets(body, "ep.md")
     assert len(findings) == 2
     assert all(f.severity == "error" for f in findings)
+    assert sorted(f.line for f in findings) == [2, 3]
 
 
 def test_placeholder_bullets_real_keypoint_is_silent():

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -23,6 +23,7 @@ from checker.lesson_check import (
     check_config,
     check_episode,
     check_support_files,
+    read_lesson_metadata,
     resolve_glossary_path,
 )
 
@@ -708,3 +709,73 @@ def test_check_episode_reports_real_file_line_numbers_not_body_relative(tmp_path
     heading_findings = [f for f in findings if "Stray H1" in f.message]
     assert heading_findings, "expected a level-1 heading finding"
     assert f"line {real_line}" in heading_findings[0].message
+
+
+# -- read_lesson_metadata ---------------------------------------------------
+
+
+def test_read_lesson_metadata_full_config_and_citation(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "title: 'Python Intro'\n"
+        "carpentry: 'lc'\n"
+        "life_cycle: 'beta'\n"
+        "license: 'CC-BY 4.0'\n"
+        "source: 'https://github.com/org/repo'\n"
+        "contact: 'team@example.org'\n"
+        "created: '2020-01-01'\n"
+    )
+    (tmp_path / "CITATION.cff").write_text(
+        "authors:\n"
+        "  - family-names: Hennesy\n"
+        "    given-names: Cody\n"
+        "  - family-names: Org\n"
+        "    given-names: An\n"
+    )
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.title == "Python Intro"
+    assert metadata.carpentry == "Library Carpentry"
+    assert metadata.life_cycle == "beta"
+    assert metadata.license == "CC-BY 4.0"
+    assert metadata.source == "https://github.com/org/repo"
+    assert metadata.contact == "team@example.org"
+    assert metadata.created == "2020-01-01"
+    assert metadata.authors == ["Cody Hennesy", "An Org"]
+
+
+def test_read_lesson_metadata_no_config_or_citation_is_empty(tmp_path):
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.title is None
+    assert metadata.authors == []
+    assert metadata.has_content() is False
+
+
+def test_read_lesson_metadata_missing_citation_leaves_authors_empty(tmp_path):
+    (tmp_path / "config.yaml").write_text("title: 'Some Lesson'\ncarpentry: 'dc'\n")
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.title == "Some Lesson"
+    assert metadata.carpentry == "Data Carpentry"
+    assert metadata.authors == []
+    assert metadata.has_content() is True
+
+
+def test_read_lesson_metadata_citation_entity_author_uses_name_field(tmp_path):
+    # CFF allows an "entity" author (an organization) via `name` instead of
+    # the usual given-names/family-names pair.
+    (tmp_path / "config.yaml").write_text("title: 'Some Lesson'\n")
+    (tmp_path / "CITATION.cff").write_text("authors:\n  - name: The Carpentries\n")
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.authors == ["The Carpentries"]
+
+
+def test_read_lesson_metadata_unknown_carpentry_code_passes_through(tmp_path):
+    (tmp_path / "config.yaml").write_text("carpentry: 'xyz'\n")
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.carpentry == "xyz"
+
+
+def test_read_lesson_metadata_malformed_yaml_is_empty_not_a_crash(tmp_path):
+    (tmp_path / "config.yaml").write_text("title: [unterminated\n")
+    (tmp_path / "CITATION.cff").write_text("authors: [unterminated\n")
+    metadata = read_lesson_metadata(tmp_path)
+    assert metadata.title is None
+    assert metadata.authors == []

--- a/tests/test_lesson_check.py
+++ b/tests/test_lesson_check.py
@@ -20,12 +20,16 @@ from checker.lesson_check import (
     _check_links,
     _check_objective_verbs,
     _check_placeholder_bullets,
+    _looks_misplaced,
+    _unlisted_episode_files,
     check_config,
     check_episode,
     check_support_files,
     read_lesson_metadata,
     resolve_glossary_path,
+    run_checks,
 )
+from checker.report import Finding
 
 VALID_EPISODE_BODY = """\
 :::::: questions
@@ -779,3 +783,92 @@ def test_read_lesson_metadata_malformed_yaml_is_empty_not_a_crash(tmp_path):
     metadata = read_lesson_metadata(tmp_path)
     assert metadata.title is None
     assert metadata.authors == []
+
+
+# -- misplaced-episode-file detection (unlisted + zero required divs) -------
+#
+# Real bug: a glossary/resources file dropped in episodes/ instead of
+# learners/reference.md, unlisted in config.yaml, structurally nothing like
+# an episode -- previously only produced 5 generic "episode is broken"
+# errors with no hint that the actual problem was "this file doesn't belong
+# here." Filename-agnostic on purpose: the signal is "unlisted + zero of
+# the three required blocks," not a hardcoded list of suspicious names.
+
+
+def test_unlisted_episode_files_returns_files_missing_from_explicit_list(tmp_path):
+    lesson_dir = make_lesson(
+        tmp_path,
+        config_extra="episodes:\n- 01-intro.md\n",
+        episodes={"01-intro.md": episode_text(), "glossary.md": "# Glossary\n\nSome terms.\n"},
+    )
+    assert _unlisted_episode_files(lesson_dir) == ["glossary.md"]
+
+
+def test_unlisted_episode_files_empty_when_episodes_field_blank(tmp_path):
+    # A blank `episodes:` is documented Workbench behavior: sandpaper
+    # includes everything automatically, so nothing counts as "unlisted".
+    lesson_dir = make_lesson(
+        tmp_path, config_extra="episodes:\n", episodes={"glossary.md": "# Glossary\n"}
+    )
+    assert _unlisted_episode_files(lesson_dir) == []
+
+
+def test_looks_misplaced_true_when_all_three_required_blocks_missing():
+    findings = [
+        Finding("error", "divs", "missing required `questions` block"),
+        Finding("error", "divs", "missing required `objectives` block"),
+        Finding("error", "divs", "missing required `keypoints` block"),
+    ]
+    assert _looks_misplaced(findings) is True
+
+
+def test_looks_misplaced_false_when_one_required_block_present():
+    findings = [
+        Finding("error", "divs", "missing required `questions` block"),
+        Finding("error", "divs", "missing required `objectives` block"),
+    ]
+    assert _looks_misplaced(findings) is False
+
+
+def test_run_checks_flags_unlisted_zero_structure_file_as_misplaced(tmp_path):
+    lesson_dir = make_lesson(
+        tmp_path,
+        config_extra="episodes:\n- 01-intro.md\n",
+        episodes={
+            "01-intro.md": episode_text(),
+            "glossary.md": "# Glossary\n\nAlgorithm\n: A sequence of steps.\n",
+        },
+    )
+    findings = run_checks(lesson_dir)
+    matches = [f for f in findings if "looks like reference content" in f.message]
+    assert len(matches) == 1
+    assert matches[0].location == "episodes/glossary.md"
+    assert matches[0].severity == "warning"
+
+
+def test_run_checks_does_not_flag_listed_zero_structure_file(tmp_path):
+    # If the author DID list it in config.yaml, that's a declared intent
+    # for it to be a real episode -- just very unwritten, not misplaced.
+    lesson_dir = make_lesson(
+        tmp_path,
+        config_extra="episodes:\n- 01-intro.md\n- draft.md\n",
+        episodes={"01-intro.md": episode_text(), "draft.md": "# Draft\n\nNothing yet.\n"},
+    )
+    findings = run_checks(lesson_dir)
+    assert not any("looks like reference content" in f.message for f in findings)
+
+
+def test_run_checks_does_not_flag_unlisted_file_with_partial_structure(tmp_path):
+    # Some required blocks present (even if incomplete) means this is a
+    # real, if broken, episode attempt -- not misplaced reference content.
+    lesson_dir = make_lesson(
+        tmp_path,
+        config_extra="episodes:\n- 01-intro.md\n",
+        episodes={
+            "01-intro.md": episode_text(),
+            "in-progress.md": "---\ntitle: 'WIP'\nteaching: 10\nexercises: 10\n---\n"
+            ":::: keypoints\n- something\n::::\n",
+        },
+    )
+    findings = run_checks(lesson_dir)
+    assert not any("looks like reference content" in f.message for f in findings)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import json
 
+import yaml
+
 from checker import __version__
-from checker.report import Finding, LessonMetadata, render_json, render_markdown, render_terminal
+from checker.report import (
+    _EXTENSION_SRC,
+    Finding,
+    LessonMetadata,
+    render_json,
+    render_markdown,
+    render_terminal,
+)
 
 
 def test_render_markdown_blame_annotates_heading():
@@ -216,3 +225,25 @@ def test_render_json_includes_generated_by_and_lesson():
 def test_render_json_no_metadata_lesson_is_none():
     payload = json.loads(render_json([], "Report"))
     assert payload["lesson"] is None
+
+
+# -- checker-report Quarto format extension -----------------------------------
+#
+# These don't invoke quarto itself (no automated test does, consistent with
+# the rest of this file -- see README's Testing section); they guard against
+# the extension directory being accidentally deleted, renamed, or shipping
+# invalid YAML, which _render_via_quarto would otherwise only surface as a
+# runtime failure the next time someone actually runs --html/--pdf.
+
+
+def test_extension_directory_exists():
+    assert _EXTENSION_SRC.is_dir()
+    assert (_EXTENSION_SRC / "_extension.yml").is_file()
+    assert (_EXTENSION_SRC / "checker-report.scss").is_file()
+
+
+def test_extension_yml_is_valid_and_declares_html_and_pdf_formats():
+    manifest = yaml.safe_load((_EXTENSION_SRC / "_extension.yml").read_text())
+    formats = manifest["contributes"]["formats"]
+    assert "html" in formats
+    assert "pdf" in formats

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -35,3 +35,102 @@ def test_render_terminal_blame_annotates_heading():
         findings, "Report", blame={"episodes/ep.md": "Karla Padilla, 2026-08-28, deadbee"}
     )
     assert "(last change authored by: Karla Padilla, 2026-08-28, deadbee)" in text
+
+
+# -- structured line numbers + clickable links -------------------------------
+
+
+def test_render_terminal_includes_path_colon_line_token():
+    findings = [Finding("error", "headings", "bad heading", location="episodes/ep.md", line=12)]
+    text = render_terminal(findings, "Report")
+    assert "episodes/ep.md:12 " in text
+
+
+def test_render_terminal_no_line_omits_token():
+    findings = [Finding("error", "headings", "bad heading", location="episodes/ep.md")]
+    text = render_terminal(findings, "Report")
+    assert "episodes/ep.md:" not in text
+
+
+def test_render_markdown_no_github_base_uses_plain_code_span():
+    findings = [Finding("error", "headings", "bad heading", location="episodes/ep.md", line=12)]
+    text = render_markdown(findings, "Report")
+    assert "`episodes/ep.md:12`" in text
+
+
+def test_render_markdown_github_base_makes_blob_link_with_line_anchor():
+    findings = [Finding("error", "headings", "bad heading", location="episodes/ep.md", line=12)]
+    text = render_markdown(
+        findings, "Report", github_base="https://github.com/org/repo/blob/abc123"
+    )
+    assert (
+        "[episodes/ep.md:12](https://github.com/org/repo/blob/abc123/episodes/ep.md#L12)" in text
+    )
+
+
+def test_render_markdown_github_base_no_line_omits_anchor():
+    findings = [Finding("error", "config", "bad config", location="config.yaml")]
+    text = render_markdown(
+        findings, "Report", github_base="https://github.com/org/repo/blob/abc123"
+    )
+    assert "[config.yaml](https://github.com/org/repo/blob/abc123/config.yaml)" in text
+
+
+# -- category guide links -----------------------------------------------------
+
+
+def test_render_terminal_appends_guide_link_when_no_hint():
+    findings = [Finding("warning", "divs", "unrecognized div", location="episodes/ep.md")]
+    text = render_terminal(findings, "Report")
+    assert "Workbench Component Guide" in text
+    assert "https://carpentries.github.io/sandpaper-docs/component-guide.html" in text
+
+
+def test_render_terminal_appends_guide_link_after_hint():
+    findings = [
+        Finding("warning", "divs", "unrecognized div", location="episodes/ep.md", hint="fix it")
+    ]
+    text = render_terminal(findings, "Report")
+    assert "fix it (see: Workbench Component Guide" in text
+
+
+def test_render_terminal_boilerplate_has_no_guide_link():
+    # boilerplate is a tool-invented check with no canonical external doc --
+    # see the comment on CATEGORY_GUIDE_LINKS in report.py.
+    findings = [Finding("warning", "boilerplate", "still scaffold", location="episodes/ep.md")]
+    text = render_terminal(findings, "Report")
+    assert "carpentries.github.io" not in text
+    assert "github.com" not in text
+
+
+def test_render_markdown_guide_link_is_markdown_formatted():
+    findings = [Finding("warning", "divs", "unrecognized div", location="episodes/ep.md")]
+    text = render_markdown(findings, "Report")
+    assert (
+        "[Workbench Component Guide]"
+        "(https://carpentries.github.io/sandpaper-docs/component-guide.html)" in text
+    )
+
+
+# -- file-level checklist overview --------------------------------------------
+
+
+def test_render_markdown_files_section_lists_each_location_with_issue_count():
+    findings = [
+        Finding("error", "headings", "bad heading", location="episodes/01-intro.md"),
+        Finding("warning", "links", "bad link", location="episodes/01-intro.md"),
+        Finding("info", "style", "note only", location="episodes/02-more.md"),
+    ]
+    text = render_markdown(findings, "Report")
+    assert "## Files" in text
+    assert "- [ ] [episodes/01-intro.md](#episodes01-intromd) — 2 issue(s)" in text
+    assert "- [episodes/02-more.md](#episodes02-moremd) — 1 note(s) only" in text
+
+
+def test_render_markdown_files_section_links_match_heading_anchors():
+    # GFM would slugify "## episodes/01-intro.md" to this anchor -- the
+    # checklist's link target must actually match what GitHub renders.
+    findings = [Finding("error", "headings", "bad heading", location="episodes/01-intro.md")]
+    text = render_markdown(findings, "Report")
+    assert "(#episodes01-intromd)" in text
+    assert "## episodes/01-intro.md" in text

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from checker.report import Finding, render_markdown, render_terminal
+import json
+
+from checker import __version__
+from checker.report import Finding, LessonMetadata, render_json, render_markdown, render_terminal
 
 
 def test_render_markdown_blame_annotates_heading():
@@ -134,3 +137,82 @@ def test_render_markdown_files_section_links_match_heading_anchors():
     text = render_markdown(findings, "Report")
     assert "(#episodes01-intromd)" in text
     assert "## episodes/01-intro.md" in text
+
+
+# -- tool version + lesson metadata in the report header ---------------------
+
+
+def _sample_metadata() -> LessonMetadata:
+    return LessonMetadata(
+        title="Python Intro for Libraries",
+        carpentry="Library Carpentry",
+        life_cycle="beta",
+        license="CC-BY 4.0",
+        source="https://github.com/org/repo",
+        contact="team@example.org",
+        created="2020-01-01",
+        authors=["Cody Hennesy", "Tim Dennis"],
+    )
+
+
+def test_render_markdown_includes_tool_version():
+    text = render_markdown([], "Report")
+    assert f"carpentries-workbench-checker v{__version__}" in text
+
+
+def test_render_terminal_includes_tool_version():
+    text = render_terminal([], "Report")
+    assert f"carpentries-workbench-checker v{__version__}" in text
+
+
+def test_render_markdown_no_metadata_omits_lesson_block():
+    text = render_markdown([], "Report")
+    assert "Authors:" not in text
+    assert "Source:" not in text
+
+
+def test_render_markdown_empty_metadata_omits_lesson_block():
+    text = render_markdown([], "Report", metadata=LessonMetadata())
+    assert "Authors:" not in text
+    assert "Source:" not in text
+
+
+def test_render_markdown_metadata_includes_lesson_identity():
+    text = render_markdown([], "Report", metadata=_sample_metadata())
+    assert "**Python Intro for Libraries**" in text
+    assert "Library Carpentry" in text
+    assert "life cycle: beta" in text
+    assert "license: CC-BY 4.0" in text
+    assert "Source: https://github.com/org/repo" in text
+    assert "Authors: Cody Hennesy, Tim Dennis" in text
+    assert "Contact: team@example.org" in text
+
+
+def test_render_terminal_metadata_includes_lesson_identity():
+    text = render_terminal([], "Report", metadata=_sample_metadata())
+    assert "Python Intro for Libraries" in text
+    assert "Authors: Cody Hennesy, Tim Dennis" in text
+
+
+def test_render_markdown_metadata_partial_fields_only_shows_present_ones():
+    metadata = LessonMetadata(title="Some Lesson")
+    text = render_markdown([], "Report", metadata=metadata)
+    assert "**Some Lesson**" in text
+    assert "Authors:" not in text
+    assert "Source:" not in text
+    assert "Contact:" not in text
+
+
+def test_render_json_includes_generated_by_and_lesson():
+    payload = json.loads(render_json([], "Report", metadata=_sample_metadata()))
+    assert payload["generated_by"] == {
+        "name": "carpentries-workbench-checker",
+        "version": __version__,
+    }
+    assert payload["lesson"]["title"] == "Python Intro for Libraries"
+    assert payload["lesson"]["authors"] == ["Cody Hennesy", "Tim Dennis"]
+
+
+def test_render_json_no_metadata_lesson_is_none():
+    payload = json.loads(render_json([], "Report"))
+    assert payload["lesson"] is None

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,6 +11,8 @@ from checker.report import (
     _EXTENSION_SRC,
     Finding,
     LessonMetadata,
+    _anchor,
+    _grouped_sections,
     render_json,
     render_markdown,
     render_terminal,
@@ -30,14 +32,14 @@ def test_render_markdown_blame_annotates_heading():
 def test_render_markdown_no_blame_arg_is_unchanged():
     findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
     text = render_markdown(findings, "Report")
-    assert "## episodes/ep.md\n" in text
+    assert "episodes/ep.md" in text
     assert "last change authored by" not in text
 
 
 def test_render_markdown_blame_missing_location_is_silent():
     findings = [Finding("error", "boilerplate", "still scaffold", location="episodes/ep.md")]
     text = render_markdown(findings, "Report", blame={"episodes/other.md": "Someone Else"})
-    assert "## episodes/ep.md\n" in text
+    assert "episodes/ep.md" in text
     assert "last change authored by" not in text
 
 
@@ -139,13 +141,159 @@ def test_render_markdown_files_section_lists_each_location_with_issue_count():
     assert "- [episodes/02-more.md](#episodes02-moremd) — 1 note(s) only" in text
 
 
-def test_render_markdown_files_section_links_match_heading_anchors():
-    # GFM would slugify "## episodes/01-intro.md" to this anchor -- the
-    # checklist's link target must actually match what GitHub renders.
+def test_render_markdown_files_section_links_match_detail_section_heading():
+    # File-first grouping means a file corresponds to exactly one detail
+    # section again -- the checklist's anchor link must match what GitHub
+    # would slugify that section's `## episodes/01-intro.md` heading to.
     findings = [Finding("error", "headings", "bad heading", location="episodes/01-intro.md")]
     text = render_markdown(findings, "Report")
     assert "(#episodes01-intromd)" in text
     assert "## episodes/01-intro.md" in text
+
+
+# -- severity/category/shared-fix grouping ------------------------------------
+#
+# The core of this round: 14 findings sharing one root cause should read as
+# one change applied in 14 places, not 14 visually-identical scattered
+# lines. See design/validation-prompt-report-scannability-2026-08-31.md.
+
+
+def test_grouped_sections_merges_findings_sharing_identical_hint():
+    findings = [
+        Finding("warning", "headings", "dup A", location="ep.md", hint="Use a unique heading."),
+        Finding("warning", "headings", "dup B", location="ep.md", hint="Use a unique heading."),
+        Finding("warning", "headings", "dup C", location="ep2.md", hint="Use a unique heading."),
+    ]
+    sections = _grouped_sections(findings)
+    assert len(sections) == 1
+    severity, category, hint, items = sections[0]
+    assert (severity, category, hint) == ("warning", "headings", "Use a unique heading.")
+    assert len(items) == 3
+
+
+def test_grouped_sections_does_not_merge_different_hints_in_same_category():
+    findings = [
+        Finding("warning", "headings", "a", location="ep.md", hint="Fix A"),
+        Finding("warning", "headings", "b", location="ep.md", hint="Fix B"),
+    ]
+    sections = _grouped_sections(findings)
+    assert len(sections) == 2
+    assert {hint for _, _, hint, _ in sections} == {"Fix A", "Fix B"}
+
+
+def test_grouped_sections_never_merges_hint_less_findings():
+    # Two unrelated problems that both happen to lack a hint are not the
+    # same fix -- each must stay its own singleton, not collapse into one
+    # group just because hint is None for both.
+    findings = [
+        Finding("warning", "headings", "unrelated problem one", location="ep.md"),
+        Finding("warning", "headings", "unrelated problem two", location="ep.md"),
+    ]
+    sections = _grouped_sections(findings)
+    assert len(sections) == 2
+    assert all(hint is None for _, _, hint, _ in sections)
+    assert {items[0].message for _, _, _, items in sections} == {
+        "unrelated problem one",
+        "unrelated problem two",
+    }
+
+
+def test_grouped_sections_orders_severity_errors_before_warnings_before_info():
+    findings = [
+        Finding("info", "style", "note", location="ep.md"),
+        Finding("error", "config", "bad config", location="config.yaml"),
+        Finding("warning", "links", "bad link", location="ep.md"),
+    ]
+    sections = _grouped_sections(findings)
+    assert [severity for severity, _, _, _ in sections] == ["error", "warning", "info"]
+
+
+def test_render_markdown_shared_hint_group_shows_guide_once_not_per_occurrence():
+    findings = [
+        Finding("warning", "headings", "dup A", location="ep.md", line=1, hint="Use a unique heading."),
+        Finding("warning", "headings", "dup B", location="ep.md", line=2, hint="Use a unique heading."),
+    ]
+    text = render_markdown(findings, "Report")
+    assert text.count("**Guide:**") == 1
+    assert text.count("**Change:** Use a unique heading.") == 1
+    # occurrence checklist still present, one line per finding (plus the
+    # unrelated Files-section checkbox for this same file, hence 3 not 2)
+    assert text.count("> - [ ]") == 2
+    assert text.count("- [ ]") == 3
+
+
+def test_render_markdown_hint_less_finding_has_no_change_line():
+    findings = [Finding("warning", "headings", "some problem", location="ep.md")]
+    text = render_markdown(findings, "Report")
+    assert "**Change:**" not in text
+
+
+def test_render_markdown_boilerplate_group_has_no_guide_line():
+    findings = [Finding("warning", "boilerplate", "still scaffold", location="ep.md")]
+    text = render_markdown(findings, "Report")
+    assert "**Guide:**" not in text
+
+
+def test_render_markdown_action_summary_has_one_row_per_shared_fix():
+    # Repeated problem: 3 occurrences of the same fix in different files
+    # should be one Action Summary row with Occurrences=3, Files=2 -- not
+    # 3 separate rows.
+    findings = [
+        Finding("warning", "headings", "dup A", location="ep.md", hint="Use a unique heading."),
+        Finding("warning", "headings", "dup B", location="ep.md", hint="Use a unique heading."),
+        Finding("warning", "headings", "dup C", location="ep2.md", hint="Use a unique heading."),
+    ]
+    text = render_markdown(findings, "Report")
+    assert "| ⚠️ Warning | Use a unique heading. | 3 | 2 |" in text
+
+
+def test_render_markdown_action_summary_hint_less_row_uses_message():
+    findings = [Finding("error", "config", "bad config value", location="config.yaml")]
+    text = render_markdown(findings, "Report")
+    assert "| ❌ Error | bad config value | 1 | 1 |" in text
+
+
+def test_render_markdown_detail_section_is_file_first():
+    # Two files, each with one finding of a different category -- the
+    # detail section must group by file (one `## location` heading each),
+    # not by category, so someone editing one file sees everything about
+    # that file in one place.
+    findings = [
+        Finding("warning", "headings", "dup", location="a.md", hint="Fix headings"),
+        Finding("warning", "links", "bad link", location="b.md", hint="Fix links"),
+    ]
+    text = render_markdown(findings, "Report")
+    a_pos = text.index("## a.md")
+    b_pos = text.index("## b.md")
+    fix_headings_pos = text.index("**Change:** Fix headings")
+    fix_links_pos = text.index("**Change:** Fix links")
+    assert a_pos < fix_headings_pos < b_pos < fix_links_pos
+
+
+def test_render_markdown_file_section_collapses_same_fix_within_file():
+    findings = [
+        Finding("warning", "headings", "dup A", location="ep.md", line=1, hint="Use a unique heading."),
+        Finding("warning", "headings", "dup B", location="ep.md", line=2, hint="Use a unique heading."),
+        Finding("error", "links", "bad link", location="ep.md", line=3, hint="Fix the link."),
+    ]
+    text = render_markdown(findings, "Report")
+    # one file section, containing two Change groups (mixed severities)
+    assert text.count("## ep.md") == 1
+    assert text.count("**Change:** Use a unique heading.") == 1
+    assert text.count("**Change:** Fix the link.") == 1
+    assert "❌" in text  # the error occurrence's own icon, since severity
+    assert "⚠️" in text  # is no longer implied by an enclosing heading
+
+
+def test_anchor_handles_prose_headings_with_punctuation():
+    assert _anchor("Headings — 14 warning(s)") == "headings-14-warnings"
+
+
+def test_anchor_matches_old_path_slugification():
+    # Regression: the generalized _anchor() must still slugify a bare file
+    # path the same way GitHub does, since this behavior predates the
+    # prose-heading use case and other code may still rely on it.
+    assert _anchor("episodes/01-intro.md") == "episodes01-intromd"
 
 
 # -- tool version + lesson metadata in the report header ---------------------


### PR DESCRIPTION
## Summary
- Findings carry a structured `line` field (not just prose), so renderers can build real links from it.
- Terminal output gets plain `path:line` tokens (VS Code's integrated terminal auto-links these); markdown gets real GitHub blob links anchored to the line when the lesson dir is a GitHub repo, falling back to plain text otherwise.
- Every check category now links to its authoritative Workbench/Carpentries doc, not just a few ad-hoc ones.
- The markdown report opens with a **Files** checklist (one checkbox per location, issue count, jump link) before the per-finding detail.
- New `--open` flag launches the rendered HTML report in the default browser.
- Fixed a real bug in `render_html_via_quarto` found via smoke-testing this PR: `tempfile.TemporaryDirectory()` on macOS resolves through a `/var` -> `/private/var` symlink, which made quarto compute the wrong relative output path and fail with a permission error. Now resolved before use.

## Test plan
- [x] `pixi run test` — 105 passed
- [x] `pixi run lint` — clean
- [x] Smoke-tested `--format markdown --output ... --html --open` against a real lesson repo (agentic-research-workflows): file checklist, GitHub blob links with `#L` anchors, and HTML render all verified correct